### PR TITLE
Add tests for Groups and part of User

### DIFF
--- a/fixtures.py
+++ b/fixtures.py
@@ -14,22 +14,19 @@ User.objects.create_roles()
 User.objects.create_superuser(
     email_address='a@a.com',
     username='a',
-    password='a',
-    role=1
+    password='a'
 )
 
 HIEU = User.objects.create_superuser(
     email_address='hieu@gmail.com',
     username='hieu',
-    password='a',
-    role=1
+    password='a'
 )
 
 SON = User.objects.create_superuser(
     email_address='son@gmail.com',
     username='son',
-    password='a',
-    role=0
+    password='a'
 )
 
 HIEU_GROUP = Group.objects.create_group(

--- a/kidsbook/group/tests.py
+++ b/kidsbook/group/tests.py
@@ -1,0 +1,162 @@
+import json
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from kidsbook.models import Group
+from kidsbook.serializers import GroupSerializer
+from kidsbook.user.views import generate_token
+
+User = get_user_model()
+
+url_prefix = '/api/v1'
+
+class TestGroup(APITestCase):
+    def setUp(self):
+        self.url = url_prefix + '/group/'
+        self.username = "john"
+        self.email = "john@snow.com"
+        self.password = "you_know_nothing"
+        self.user = User.objects.create_user(self.username, self.email, self.password)
+        token = generate_token(self.user)
+        self.token = 'Bearer {0}'.format(token.decode('utf-8'))
+        self.api_authentication(self.token)
+
+    def api_authentication(self, token):
+        self.client.credentials(HTTP_AUTHORIZATION=self.token)
+
+    def test_create_group(self):
+        response = self.client.post(self.url, {"name": "testing group"})
+        self.assertEqual(201, response.status_code)
+
+    def test_create_existing_group(self):
+        self.client.post(self.url, {"name": "testing group"})
+        response = self.client.post(self.url, {"name": "testing group"})
+        self.assertEqual(400, response.status_code)
+
+    def test_get_all_groups(self):
+        response = self.client.get(self.url)
+        self.assertEqual(200, response.status_code)
+
+
+class TestGroupMember(APITestCase):
+    def setUp(self):
+        # Creator
+        self.username = "john"
+        self.email = "john@snow.com"
+        self.password = "you_know_nothing"
+        self.creator = User.objects.create_user(self.username, self.email, self.password)
+        token = generate_token(self.creator)
+        self.creator_token = 'Bearer {0}'.format(token.decode('utf-8'))
+
+        # User
+        self.username = "hey"
+        self.email = "kid@s.sss"
+        self.password = "want_some_cookies?"
+        self.member = User.objects.create_user(self.username, self.email, self.password)
+        token = generate_token(self.member)
+        self.member_token = 'Bearer {0}'.format(token.decode('utf-8'))
+
+        # Group
+        response = self.client.post(url_prefix + '/group/', {"name": "testing group"}, HTTP_AUTHORIZATION=self.creator_token)
+        self.group_id = response.data.get('created_group_id', '')
+
+        self.url = "{}/group/{}".format(url_prefix, self.group_id)
+
+
+    def test_add_new_group_member(self):
+        response = self.client.post(self.url + '/user/' + str(self.member.id), HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(202, response.status_code)
+
+    def test_add_new_group_member_by_non_creator(self):
+        self.client.post(self.url + '/user/' + str(self.member.id), HTTP_AUTHORIZATION=self.creator_token)
+
+        username = "Another"
+        email = "one@b.ites"
+        password = "the_dust"
+        user = User.objects.create_user(username, email, password)
+
+        # Add the user to be a member
+        url = self.url + '/user/' + str(user.id)
+        response = self.client.post(url, HTTP_AUTHORIZATION=self.member_token)
+
+        self.assertEqual(403, response.status_code)
+
+    def test_add_duplicated_group_member(self):
+        url = self.url + '/user/' + str(self.member.id)
+        self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
+        response = self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(400, response.status_code)
+
+    def test_delete_group_member(self):
+        url = self.url + '/user/' + str(self.member.id)
+        self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(202, response.status_code)
+
+    def test_delete_group_member_by_non_creator(self):
+        self.client.post(self.url + '/user/' + str(self.member.id), HTTP_AUTHORIZATION=self.creator_token)
+
+        username = "Another"
+        email = "one@b.ites"
+        password = "the_dust"
+        user = User.objects.create_user(username, email, password)
+
+        # Add the user to be a member
+        url = self.url + '/user/' + str(user.id)
+        self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.member_token)
+
+        self.assertEqual(403, response.status_code)
+
+
+    def test_delete_not_joined_group_member(self):
+        username = "Another"
+        email = "one@b.ites"
+        password = "the_dust"
+        user = User.objects.create_user(username, email, password)
+
+        url = self.url + '/user/' + str(user.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(400, response.status_code)
+
+    def test_delete_group_creator(self):
+        url = self.url + '/user/' + str(self.creator.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(400, response.status_code)
+
+
+class TestGroupManage(APITestCase):
+    def setUp(self):
+        self.url = url_prefix + '/group/'
+
+        # Creator
+        self.username = "john"
+        self.email = "john@snow.com"
+        self.password = "you_know_nothing"
+        self.creator = User.objects.create_user(self.username, self.email, self.password)
+        token = generate_token(self.creator)
+        self.creator_token = 'Bearer {0}'.format(token.decode('utf-8'))
+
+    def test_delete_group(self):
+        response = self.client.post(self.url, {"name": "testing group"}, HTTP_AUTHORIZATION=self.creator_token)
+        group_id = str(response.data.get('created_group_id', ''))
+        url = self.url + group_id
+
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(202, response.status_code)
+
+    def test_delete_group_by_non_creator(self):
+        # Create a group
+        group_response = self.client.post(self.url, {"name": "testing group"}, HTTP_AUTHORIZATION=self.creator_token)
+        group_id = str(group_response.data.get('created_group_id', ''))
+        url = self.url + group_id
+
+        # Creat a non-creator
+        username = "james"
+        email = "james@yong.com"
+        password = "testing_ppp"
+        user = User.objects.create_user(username, email, password)
+        token = 'Bearer {0}'.format(generate_token(user).decode('utf-8'))
+
+        response = self.client.delete(url, HTTP_AUTHORIZATION=token)
+        self.assertEqual(403, response.status_code)

--- a/kidsbook/group/urls.py
+++ b/kidsbook/group/urls.py
@@ -6,10 +6,9 @@ urlpatterns = [
 
     # Return all groups or create a new group
     path('', views.group),
-    #path('', views.GroupCreateAndGet.as_view()),
 
     # Add new member or remove a member in a group
-    path('<group_id>/user/<user_id>', views.group_member),
+    path('<group_id>/user/<user_id>/', views.group_member),
 
-    path('<group_id>', views.delele_group)
+    path('<group_id>/', views.delete_group)
 ]

--- a/kidsbook/group/views.py
+++ b/kidsbook/group/views.py
@@ -21,9 +21,7 @@ class IsGroupCreator(BasePermission):
         group_id = view.kwargs.get('group_id', None)
         #sender_id = request.data.get('sender_id', None)
         sender_id = request.user.id
-        print(sender_id)
-        print(type(sender_id))
-        print(str(Group.objects.get(id=group_id).creator.id))
+
         # If sender is not the Creator of group
         if not sender_id or str(sender_id) != str(Group.objects.get(id=group_id).creator.id):
             return False
@@ -99,10 +97,8 @@ def delete_member_from_group(user, group):
     # Remove the link between the user and group
     if user.id == group.creator.id:
         raise ValueError('Cannot delete the Creator from the group.')
-        
+
     GroupMember.objects.get(user_id=user.id, group_id=group.id).delete()
-
-
 
 @api_view(['POST', 'DELETE'])
 @permission_classes((IsAuthenticated, IsGroupCreator))
@@ -136,8 +132,9 @@ def group_member(request, **kargs):
 
 @api_view(['DELETE'])
 @permission_classes((IsAuthenticated, IsGroupCreator))
-def delele_group(request, **kargs):
+def delete_group(request, **kargs):
     """Delete a group."""
+
     try:
         group_id = kargs.get('group_id', None)
         if group_id:
@@ -145,7 +142,6 @@ def delele_group(request, **kargs):
 
             # The relations in GroupMember table are also auto-removed
             target_group.delete()
-
             return Response({'result': 'Successful'}, status=status.HTTP_202_ACCEPTED)
     except Exception:
         pass

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -26,8 +26,8 @@ class UserManager(BaseUserManager):
     # use_in_migrations = True
 
     def create_roles(self):
-        role1 = Role(id=0, name='student')
-        role2 = Role(id=1, name='teacher')
+        role1 = Role(id=1, name='teacher')
+        role2 = Role(id=2, name='student')
         role1.save()
         role2.save()
 
@@ -42,21 +42,21 @@ class UserManager(BaseUserManager):
         user = self.model(username=username, email_address=email_address, **extra_fields)
         user.role = Role(id=role)
         user.set_password(password)
-        print("ABOUT TO SAVE")
-        print(self._db)
+        #print("ABOUT TO SAVE")
+        #print(self._db)
         try:
             user.save(using=self._db)
-            print("HIEU")
+            #print("HIEU")
         except Exception as e:
             print(e)
         return user
 
-    def create_user(self, username, email_address=None, password=None, role=None, **extra_fields):
+    def create_user(self, username, email_address=None, password=None, **extra_fields):
         extra_fields.setdefault('is_staff', False)
         extra_fields.setdefault('is_superuser', False)
-        return self._create_user(username, email_address, password, role, **extra_fields)
+        return self._create_user(username, email_address, password, 2, **extra_fields)
 
-    def create_superuser(self, username, email_address, password, role, **extra_fields):
+    def create_superuser(self, username, email_address, password, **extra_fields):
         extra_fields.setdefault('is_staff', True)
         extra_fields.setdefault('is_superuser', True)
 
@@ -65,7 +65,7 @@ class UserManager(BaseUserManager):
         if extra_fields.get('is_superuser') is not True:
             raise ValueError('Superuser must have is_superuser=True.')
 
-        return self._create_user(username, email_address, password, role, **extra_fields)
+        return self._create_user(username, email_address, password, 1, **extra_fields)
 
 
 class User(AbstractBaseUser, PermissionsMixin):

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -8,7 +8,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'username', 'email_address', 'is_active', 'is_staff')
-        # fields = ('email_address',)
+        
 
 class PostSerializer(serializers.ModelSerializer):
 

--- a/kidsbook/user/tests.py
+++ b/kidsbook/user/tests.py
@@ -1,0 +1,61 @@
+import json
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+from kidsbook.models import Group
+from kidsbook.serializers import GroupSerializer
+from kidsbook.user.views import generate_token
+
+User = get_user_model()
+
+url_prefix = '/api/v1'
+
+class TestUser(APITestCase):
+    def setUp(self):
+        self.url = url_prefix + '/user/'
+        self.username = "john"
+        self.email = "john@snow.com"
+        self.password = "you_know_nothing"
+        self.user = User.objects.create_user(self.username, self.email, self.password)
+
+
+    def test_login(self):
+        url = self.url + 'login/'
+        response = self.client.post(url, data={'email_address': self.email})
+        self.assertEqual(200, response.status_code)
+
+    def test_get_self_user_profile_with_token(self):
+        token_response = self.client.post(self.url + 'login/', data={'email_address': self.email})
+        token = token_response.data.get('token', b'')
+        token = 'Bearer {0}'.format(token.decode('utf-8'))
+
+        response = self.client.get(self.url + 'profile/', HTTP_AUTHORIZATION=token)
+        self.assertEqual(200, response.status_code)
+
+    def test_get_self_user_profile_without_token(self):
+        response = self.client.get(self.url + 'profile/')
+        self.assertEqual(401, response.status_code)
+
+    def test_get_user_info(self):
+        token_response = self.client.post(self.url + 'login/', data={'email_address': self.email})
+        token = token_response.data.get('token', b'')
+        token = 'Bearer {0}'.format(token.decode('utf-8'))
+
+        # Create an user
+        username = "hey"
+        email = "kid@s.sss"
+        password = "want_some_cookies?"
+        user = User.objects.create_user(username, email, password)
+
+        response = self.client.get("{}{}/".format(self.url, str(user.id)), HTTP_AUTHORIZATION=token)
+
+        self.assertEqual(200, response.status_code)
+
+    def test_get_user_info_without_token(self):
+        # Create an user
+        username = "hey"
+        email = "kid@s.sss"
+        password = "want_some_cookies?"
+        user = User.objects.create_user(username, email, password)
+
+        response = self.client.get("{}{}/".format(self.url, str(user.id)))
+        self.assertEqual(401, response.status_code)

--- a/kidsbook/user/urls.py
+++ b/kidsbook/user/urls.py
@@ -3,7 +3,10 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from kidsbook.user import views
 
 urlpatterns = [
-    path('', views.GetInfo.as_view()),
+    # Get User's Info
+    path('profile/', views.GetInfo.as_view()),
+    path('<uuid:user_id>/', views.GetInfoUser.as_view()),
+    
     path('posts/', views.GetPost.as_view()),
     path('login/', views.LogIn.as_view()),
     path('update/', views.Update.as_view()),


### PR DESCRIPTION
- Remove parameter `role` for high-level functions.
- Add unit tests for `Group` and `GroupMember`.
- Add unit tests for `/user/login`, `/user/profile/` and `/user/<user_id>` as the remains' APIs may change due to permissions.
- Change the default `Role` numbers of `Teacher` and `Student` to be 1 and 2, respectively, to reverse index `0` for a higher management.