### PR TITLE
Fix tests in `Group` causing StatusCode 301 due to missing slashes in URLs

### DIFF
--- a/kidsbook/group/tests.py
+++ b/kidsbook/group/tests.py
@@ -59,15 +59,15 @@ class TestGroupMember(APITestCase):
         response = self.client.post(url_prefix + '/group/', {"name": "testing group"}, HTTP_AUTHORIZATION=self.creator_token)
         self.group_id = response.data.get('created_group_id', '')
 
-        self.url = "{}/group/{}".format(url_prefix, self.group_id)
+        self.url = "{}/group/{}/".format(url_prefix, self.group_id)
 
 
     def test_add_new_group_member(self):
-        response = self.client.post(self.url + '/user/' + str(self.member.id), HTTP_AUTHORIZATION=self.creator_token)
+        response = self.client.post("{}user/{}/".format(self.url, str(self.member.id)), HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(202, response.status_code)
 
     def test_add_new_group_member_by_non_creator(self):
-        self.client.post(self.url + '/user/' + str(self.member.id), HTTP_AUTHORIZATION=self.creator_token)
+        self.client.post("{}user/{}/".format(self.url,str(self.member.id)), HTTP_AUTHORIZATION=self.creator_token)
 
         username = "Another"
         email = "one@b.ites"
@@ -75,25 +75,25 @@ class TestGroupMember(APITestCase):
         user = User.objects.create_user(username, email, password)
 
         # Add the user to be a member
-        url = self.url + '/user/' + str(user.id)
+        url = "{}user/{}/".format(self.url, str(user.id))
         response = self.client.post(url, HTTP_AUTHORIZATION=self.member_token)
 
         self.assertEqual(403, response.status_code)
 
     def test_add_duplicated_group_member(self):
-        url = self.url + '/user/' + str(self.member.id)
+        url = self.url + 'user/' + str(self.member.id) + '/'
         self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
         response = self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(400, response.status_code)
 
     def test_delete_group_member(self):
-        url = self.url + '/user/' + str(self.member.id)
+        url = self.url + 'user/' + str(self.member.id) + '/'
         self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
         response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(202, response.status_code)
 
     def test_delete_group_member_by_non_creator(self):
-        self.client.post(self.url + '/user/' + str(self.member.id), HTTP_AUTHORIZATION=self.creator_token)
+        self.client.post(self.url + 'user/' + str(self.member.id) + '/', HTTP_AUTHORIZATION=self.creator_token)
 
         username = "Another"
         email = "one@b.ites"
@@ -101,7 +101,7 @@ class TestGroupMember(APITestCase):
         user = User.objects.create_user(username, email, password)
 
         # Add the user to be a member
-        url = self.url + '/user/' + str(user.id)
+        url = self.url + 'user/' + str(user.id) + '/'
         self.client.post(url, HTTP_AUTHORIZATION=self.creator_token)
 
         response = self.client.delete(url, HTTP_AUTHORIZATION=self.member_token)
@@ -115,12 +115,12 @@ class TestGroupMember(APITestCase):
         password = "the_dust"
         user = User.objects.create_user(username, email, password)
 
-        url = self.url + '/user/' + str(user.id)
+        url = self.url + 'user/' + str(user.id) + '/'
         response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(400, response.status_code)
 
     def test_delete_group_creator(self):
-        url = self.url + '/user/' + str(self.creator.id)
+        url = self.url + 'user/' + str(self.creator.id) + '/'
         response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(400, response.status_code)
 
@@ -139,8 +139,11 @@ class TestGroupManage(APITestCase):
 
     def test_delete_group(self):
         response = self.client.post(self.url, {"name": "testing group"}, HTTP_AUTHORIZATION=self.creator_token)
+        with open('output.txt', 'w') as out_f:
+            out_f.write(str(response.data))
+
         group_id = str(response.data.get('created_group_id', ''))
-        url = self.url + group_id
+        url = "{}{}/".format(self.url, group_id)
 
         response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(202, response.status_code)
@@ -149,7 +152,7 @@ class TestGroupManage(APITestCase):
         # Create a group
         group_response = self.client.post(self.url, {"name": "testing group"}, HTTP_AUTHORIZATION=self.creator_token)
         group_id = str(group_response.data.get('created_group_id', ''))
-        url = self.url + group_id
+        url = self.url + group_id + '/'
 
         # Creat a non-creator
         username = "james"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+python manage.py test kidsbook/group/
+python manage.py test kidsbook/user/


### PR DESCRIPTION
- Add a `test.sh` to run all unit tests in the project.