### PR TITLE
Update branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Method | Endpoint | Arguments | Description | Permissions | Return
 --- | --- | --- | --- | --- | --- |
 `GET` | /group/<group_id>/posts/ | | Get all posts in the group. | IsAuthenticated, IsInGroup | Post: *list*
 `POST` | /group/<group_id>/posts/ | * | Create a post in the group. | IsAuthenticated, IsInGroup | Post: *dict*
+`POST` | group/<group_id>/flagged/ | Get all flagged posts in the group | IsAuthenticated, IsInGroup, IsSuperUser | Post: *list*
 `GET` | /post/<post_id>/ | | Get post's details by ID. | IsAuthenticated, HasAccessToPost | Post: *dict*
 `POST` | /post/<post_id>/ | * | Update the post. | IsAuthenticated, HasAccessToPost | Post: *dict*
 `DELETE` | /post/<post_id>/ | * | Delete the post. | IsAuthenticated, HasAccessToPost | {}

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -251,7 +251,7 @@ class CommentManager(models.Manager):
 
 class Comment(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    content = models.CharField(max_length=100)
+    content = models.CharField(max_length=2000)
     created_at = models.DateTimeField(auto_now_add=True)
 
     post = models.ForeignKey(Post, related_name='comments_post', on_delete=models.CASCADE, default=uuid.uuid4)

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -207,7 +207,7 @@ class Post(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     content = models.TextField()
     objects = PostManager()
-    creator = models.ForeignKey(User, related_name='post_owner', on_delete=models.CASCADE, default=uuid.uuid4)
+    creator = models.ForeignKey(User, related_name='user_posts', on_delete=models.CASCADE, default=uuid.uuid4)
     group = models.ForeignKey(Group, related_name='post_group', on_delete=models.CASCADE, default=uuid.uuid4)
     likes = models.ManyToManyField(User, related_name='likes', through='UserLikePost')
     shares = models.ManyToManyField(User, related_name='shares', through='UserSharePost')

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -256,6 +256,7 @@ class Comment(models.Model):
 
     post = models.ForeignKey(Post, related_name='comments_post', on_delete=models.CASCADE, default=uuid.uuid4)
     creator = models.ForeignKey(User, related_name='comment_owner', on_delete=models.CASCADE, default=uuid.uuid4)
+    likes = models.ManyToManyField(User, related_name='comment_likers', through='UserLikeComment')
 
     REQUIRED_FIELDS = ['post', 'creator', 'content']
 
@@ -277,5 +278,7 @@ class UserFlagPost(models.Model):
     post = models.ForeignKey(Post, on_delete=models.CASCADE)
     comment = models.ForeignKey(Comment, on_delete=models.CASCADE, null=True)
     status = models.CharField(max_length=120)
+    created_at = models.DateTimeField(auto_now_add=True)
+
     class Meta:
         unique_together = ["user", "comment", "post"]

--- a/kidsbook/post/tests.py
+++ b/kidsbook/post/tests.py
@@ -329,7 +329,7 @@ class TestPost(APITestCase):
         response = self.client.post(url, {"status": flag_status}, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(202, response.status_code)
         flag_id = response.data.get('data', {}).get('id', '')
-
+        
         self.assertTrue(
             UserFlagPost.objects.filter(id=flag_id).exists()
             and (UserFlagPost.objects.get(id=flag_id).status) == flag_status

--- a/kidsbook/post/urls.py
+++ b/kidsbook/post/urls.py
@@ -3,7 +3,7 @@ from kidsbook.post import views
 
 urlpatterns = [
     path('group/<uuid:pk>/posts/', views.GroupPostList.as_view()),
-    path('group/<uuid:pk>/flagged-posts/', views.GroupFlaggedPostList.as_view()),
+    path('group/<uuid:pk>/flagged/', views.GroupFlaggedList.as_view()),
     path('post/<uuid:pk>/', views.PostDetail.as_view()),
     path('post/<uuid:pk>/likes/', views.PostLike.as_view()),
     path('post/<uuid:pk>/shares/', views.PostShare.as_view()),

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -14,9 +14,11 @@ from django.http import (
 from django.contrib.auth import (
     authenticate, login, logout
 )
+from django.db.models import Case, Count, IntegerField, Sum, When
 
 from django.contrib.auth import get_user_model, get_user
 from rest_framework.permissions import IsAuthenticated, AllowAny
+from kidsbook.utils import *
 
 User = get_user_model()
 
@@ -28,14 +30,36 @@ class GroupPostList(generics.ListCreateAPIView):
     def list(self, request, **kwargs):
         try:
             queryset = self.get_queryset().filter(group = Group.objects.get(id=kwargs['pk'])).order_by('-created_at')
-        except Exception:
+
+        except Exception as e:
             return Response(status=status.HTTP_400_BAD_REQUEST)
         serializer = PostSerializer(queryset, many=True)
+        response_data =serializer.data
+
+        really_likes = UserLikeComment.objects.all().filter(like_or_dislike=True)
+        really_likes_users = User.objects.all().filter(id__in=[x.user.id for x in really_likes])
 
         for post in serializer.data:
             queryset = UserLikePost.objects.all().filter(post=Post.objects.get(id=post['id']))
             likes = PostLikeSerializer(queryset, many=True)
             post['likes_list'] = likes.data
+
+            queryset = Comment.objects.all().filter(post=Post.objects.get(id=post['id']))
+            queryset.query.group_by = ['id']
+            queryset = queryset.annotate(
+                like_count=Sum(
+                    Case(
+                        When(likes__in=really_likes_users, then=1), 
+                        default=0, output_field=IntegerField()
+                    )
+                )
+            ).order_by('-like_count', '-created_at')[:3]
+
+            comments = CommentSerializer(queryset, many=True)
+            for comment in comments.data:
+                comment['creator'] = {'id':comment['creator']['id'], 'username': comment['creator']['username']}
+            comment_data = clean_data_iterative(comments.data, 'post')
+            post['comments'] = comments.data
 
         return Response({'data': serializer.data})
 
@@ -45,18 +69,39 @@ class GroupPostList(generics.ListCreateAPIView):
         except Exception:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-class GroupFlaggedPostList(generics.ListAPIView):
+class GroupFlaggedList(generics.ListAPIView):
     queryset = Post.objects.all()
     serializer_class = PostSerializer
     permission_classes = (IsAuthenticated, IsInGroup, IsTokenValid, IsSuperUser)
 
     def list(self, request, **kwargs):
-        # try:
-        queryset = self.get_queryset().filter(group = Group.objects.get(id=kwargs['pk'])).exclude(flags__isnull = True).order_by('-created_at')
-        # except Exception:
-            # return Response(status=status.HTTP_400_BAD_REQUEST)
-        serializer = PostSerializer(queryset, many=True)
-        return Response({'data': serializer.data})
+        try:
+            queryset = Post.objects.all().filter(group = Group.objects.get(id=kwargs['pk'])).exclude(flags__isnull = True)
+            post_queryset = UserFlagPost.objects.all().filter(post__in=queryset).order_by('-created_at')
+
+            # all_posts = Post.objects.all().filter(group = Group.objects.get(id=kwargs['pk']))
+            # queryset = Comment.objects.all().filter(post__in = all_posts).exclude(flags__isnull = True)
+            # comment_queryset = UserFlagPost.objects.all().filter(comment__in=queryset).order_by('-created_at')
+
+        except Exception as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        response_data = PostFlagSerializer(post_queryset, many=True).data
+        post_data = []
+        comment_data = []
+
+        for flag in response_data:
+            flag['user_id'] = flag['user']['id']
+            flag['user_photo'] = flag['user']['profile_photo']
+            flag['user_name'] = flag['user']['realname']
+            flag.pop('user', None)
+            if(flag['comment'] == None):
+                flag.pop('comment', None)
+                post_data.append(flag)
+            else:
+                comment_data.append(flag)
+
+        return Response({'data': {'posts': post_data, 'comments': comment_data}})
 
 class PostLike(generics.ListCreateAPIView):
     queryset = UserLikePost.objects.all()

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -57,8 +57,8 @@ class GroupPostList(generics.ListCreateAPIView):
 
             comments = CommentSerializer(queryset, many=True)
             comments_data = comments.data.copy()
-            # for comment in comments.data.copy():
-            #     comment['creator'] = {'id':comment['creator']['id'], 'username': comment['creator']['username']}
+            for comment in comments.data.copy():
+                comment['creator'] = {'id':comment['creator']['id'], 'username': comment['creator']['username']}
             comment_data = clean_data_iterative(comments_data, 'post')
             post['comments'] = comments.data.copy()
 
@@ -92,10 +92,10 @@ class GroupFlaggedList(generics.ListAPIView):
         comment_data = []
 
         for flag in response_data:
-            # flag['user_id'] = flag['user']['id']
-            # flag['user_photo'] = flag['user']['profile_photo']
-            # flag['user_name'] = flag['user']['realname']
-            # flag.pop('user', None)
+            flag['user_id'] = flag['user']['id']
+            flag['user_photo'] = flag['user']['profile_photo']
+            flag['user_name'] = flag['user']['realname']
+            flag.pop('user', None)
             if(flag['comment'] == None):
                 flag.pop('comment', None)
                 post_data.append(flag)

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -11,14 +11,15 @@ import json
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'username', 'email_address', 'is_active', 'profile_photo', 'is_superuser', 'description', "realname", 'group_users')
+        fields = ('id', 'username', 'email_address', 'is_active', 'profile_photo', 'is_superuser', 'description', "realname", 'group_users', 'user_posts', 'role')
         depth = 1
 
 # This class is for public profile
 class UserPublicSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'is_active', 'is_superuser', 'profile_photo', 'username', 'description')
+        fields = ('id', 'is_active', 'is_superuser', 'profile_photo', 'username', 'description', 'user_posts', 'role')
+        depth = 1
 
 class PostSerializer(serializers.ModelSerializer):
 

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -18,7 +18,7 @@ class UserSerializer(serializers.ModelSerializer):
 class UserPublicSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'is_active', 'is_superuser', 'profile_photo', 'username', 'description', 'user_posts', 'role')
+        fields = ('id', 'is_active', 'is_superuser', 'profile_photo', 'username', 'description', 'user_posts')
         depth = 1
 
 class PostSerializer(serializers.ModelSerializer):
@@ -75,7 +75,7 @@ class PostFlagSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UserFlagPost
-        fields = ('id', 'user', 'post', 'status', 'comment')
+        fields = ('id', 'user', 'post', 'status', 'comment', 'created_at')
         depth = 1
 
     def create(self, data):
@@ -88,7 +88,7 @@ class CommentFlagSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UserFlagPost
-        fields = ('id', 'user', 'post', 'status', 'comment')
+        fields = ('id', 'user', 'post', 'status', 'comment', 'created_at')
         depth = 1
 
     def create(self, data):

--- a/kidsbook/user/tests.py
+++ b/kidsbook/user/tests.py
@@ -327,7 +327,6 @@ class TestUserUpdate(APITestCase):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../backend/media/picture.png'), 'rb') as pic:
             request_changes = {
                 'username': 'Not_doggo',
-                'password': self.password,
                 'description': 'Corki',
                 "profile_photo": pic}
             response = self.client.post(self.update_url, request_changes, HTTP_AUTHORIZATION=token)

--- a/kidsbook/user/tests.py
+++ b/kidsbook/user/tests.py
@@ -278,11 +278,10 @@ class TestUserUpdate(APITestCase):
         return token
 
     def changes_reflect_in_response(self, request_changes, previous_state, current_state):
-
         difference = { k : current_state[k] for k in set(current_state) - set(previous_state) }
 
         for key, prev_val in iter(previous_state.items()):
-            if key == 'id' or key == 'password':
+            if key in {'id', 'password', 'num_comment', 'num_like_received', 'num_like_given'}:
                 continue
 
             # If the un-modified value changes
@@ -320,20 +319,20 @@ class TestUserUpdate(APITestCase):
         response = self.client.post(self.update_url, data=data, HTTP_AUTHORIZATION=token)
         self.assertEqual(405, response.status_code)
 
-    # def test_update_by_creator(self):
-    #     token = self.get_token(self.creator)
-    #     previous_state_of_user = self.client.get("{}{}/".format(self.url, self.modify_user.id), HTTP_AUTHORIZATION=token).data.get('data', {})
+    def test_update_by_creator(self):
+        token = self.get_token(self.creator)
+        previous_state_of_user = self.client.get("{}{}/".format(self.url, self.modify_user.id), HTTP_AUTHORIZATION=token).data.get('data', {})
 
-    #     with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../backend/media/picture.png'), 'rb') as pic:
-    #         request_changes = {
-    #             'username': 'Not_doggo',
-    #             'description': 'Corki',
-    #             "profile_photo": pic}
-    #         response = self.client.post(self.update_url, request_changes, HTTP_AUTHORIZATION=token)
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../backend/media/picture.png'), 'rb') as pic:
+            request_changes = {
+                'username': 'Not_doggo',
+                'description': 'Corki',
+                "profile_photo": pic}
+            response = self.client.post(self.update_url, request_changes, HTTP_AUTHORIZATION=token)
 
-    #     self.assertTrue(
-    #         self.changes_reflect_in_response(request_changes, previous_state_of_user, response.data.get('data', {}))
-    #     )
+        self.assertTrue(
+            self.changes_reflect_in_response(request_changes, previous_state_of_user, response.data.get('data', {}))
+        )
 
     def test_update_username_to_existing(self):
         token = self.get_token(self.creator)

--- a/kidsbook/user/tests.py
+++ b/kidsbook/user/tests.py
@@ -330,8 +330,10 @@ class TestUserUpdate(APITestCase):
                 "profile_photo": pic}
             response = self.client.post(self.update_url, request_changes, HTTP_AUTHORIZATION=token)
 
+        cur_state = self.client.get("{}{}/".format(self.url, self.modify_user.id), HTTP_AUTHORIZATION=token).data.get('data', {})
+
         self.assertTrue(
-            self.changes_reflect_in_response(request_changes, previous_state_of_user, response.data.get('data', {}))
+            self.changes_reflect_in_response(request_changes, previous_state_of_user, cur_state)
         )
 
     def test_update_username_to_existing(self):

--- a/kidsbook/user/tests.py
+++ b/kidsbook/user/tests.py
@@ -320,20 +320,20 @@ class TestUserUpdate(APITestCase):
         response = self.client.post(self.update_url, data=data, HTTP_AUTHORIZATION=token)
         self.assertEqual(405, response.status_code)
 
-    def test_update_by_creator(self):
-        token = self.get_token(self.creator)
-        previous_state_of_user = self.client.get("{}{}/".format(self.url, self.modify_user.id), HTTP_AUTHORIZATION=token).data.get('data', {})
+    # def test_update_by_creator(self):
+    #     token = self.get_token(self.creator)
+    #     previous_state_of_user = self.client.get("{}{}/".format(self.url, self.modify_user.id), HTTP_AUTHORIZATION=token).data.get('data', {})
 
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../backend/media/picture.png'), 'rb') as pic:
-            request_changes = {
-                'username': 'Not_doggo',
-                'description': 'Corki',
-                "profile_photo": pic}
-            response = self.client.post(self.update_url, request_changes, HTTP_AUTHORIZATION=token)
+    #     with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../backend/media/picture.png'), 'rb') as pic:
+    #         request_changes = {
+    #             'username': 'Not_doggo',
+    #             'description': 'Corki',
+    #             "profile_photo": pic}
+    #         response = self.client.post(self.update_url, request_changes, HTTP_AUTHORIZATION=token)
 
-        self.assertTrue(
-            self.changes_reflect_in_response(request_changes, previous_state_of_user, response.data.get('data', {}))
-        )
+    #     self.assertTrue(
+    #         self.changes_reflect_in_response(request_changes, previous_state_of_user, response.data.get('data', {}))
+    #     )
 
     def test_update_username_to_existing(self):
         token = self.get_token(self.creator)

--- a/kidsbook/user/urls.py
+++ b/kidsbook/user/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path('<uuid:pk>/', views.GetInfoUser.as_view()),
     path('<uuid:pk>/groups/', views.GetGroups.as_view()),
 
-    path('posts/', views.GetPost.as_view()),
+    # path('<uuid:pk>/posts/', views.GetPost.as_view()),
     path('login/', views.LogIn.as_view()),
     path('login_as_virtual/', views.LogInAsVirtual.as_view()),
     path('register/', views.Register.as_view()),

--- a/kidsbook/user/views.py
+++ b/kidsbook/user/views.py
@@ -129,7 +129,6 @@ class Register(APIView):
         serializer = self.serializer_class(user)
         return Response({'data': serializer.data}, status=status.HTTP_202_ACCEPTED)
 
-
 class Update(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = UserSerializer
     permission_classes = (IsAuthenticated, IsTokenValid)
@@ -222,8 +221,9 @@ class GetInfoUser(generics.ListAPIView):
                 else:
                     self.serializer_class = UserPublicSerializer
                 serializer = self.serializer_class(user, many=False)
-                response_data = clean_data(serializer.data, 'group_users')
-                response_data['role'] = response_data['role']['name']
+                response_data = serializer.data
+                if('role' in response_data):
+                    response_data['role'] = response_data['role']['id']
                 comments = Comment.objects.all().filter(creator=user)
                 response_data['num_comment'] = len(comments)
 

--- a/kidsbook/user/views.py
+++ b/kidsbook/user/views.py
@@ -223,8 +223,8 @@ class GetInfoUser(generics.ListAPIView):
                 serializer = self.serializer_class(user, many=False)
                 response_data = serializer.data.copy()
 
-                # if('role' in response_data):
-                #     response_data['role'] = response_data['role']['id']
+                if('role' in response_data):
+                    response_data['role'] = response_data['role']['id']
                 comments = Comment.objects.all().filter(creator=user)
                 response_data['num_comment'] = len(comments)
 

--- a/kidsbook/user/views.py
+++ b/kidsbook/user/views.py
@@ -168,7 +168,7 @@ class Update(generics.RetrieveUpdateDestroyAPIView):
             isAuthenticate = authenticate(email_address=request.data['email'], password=request.data['oldPassword'])
             if(isAuthenticate is None):
                 res = {'error': ' Your old password is incorrect '}
-                return Response({'error': res}, status=status.HTTP_405_METHOD_NOT_ALLOWED)  
+                return Response({'error': res}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
             target_user.set_password(request.data['password'])
 
         try:
@@ -221,9 +221,10 @@ class GetInfoUser(generics.ListAPIView):
                 else:
                     self.serializer_class = UserPublicSerializer
                 serializer = self.serializer_class(user, many=False)
-                response_data = serializer.data
-                if('role' in response_data):
-                    response_data['role'] = response_data['role']['id']
+                response_data = serializer.data.copy()
+
+                # if('role' in response_data):
+                #     response_data['role'] = response_data['role']['id']
                 comments = Comment.objects.all().filter(creator=user)
                 response_data['num_comment'] = len(comments)
 
@@ -231,7 +232,6 @@ class GetInfoUser(generics.ListAPIView):
                 if('user_posts' in response_data):
                     response_data['user_posts'] = list(map(lambda post: post['id'], response_data['user_posts']))
                     for post_id in response_data['user_posts']:
-                        print(post_id)
                         post_like = UserLikePost.objects.all().filter(post=Post.objects.get(id=post_id)).filter(like_or_dislike=True)
                         post_like_received += len(post_like)
                 response_data['num_like_received'] = post_like_received

--- a/kidsbook/utils.py
+++ b/kidsbook/utils.py
@@ -1,0 +1,10 @@
+def clean_data(data, *args):
+  for field in args:
+    data.pop(field, None)
+  return data
+
+def clean_data_iterative(data, *args):
+  for row in data:
+    for field in args:
+      row.pop(field, None)
+  return data


### PR DESCRIPTION
CHANGELOG:
- Increase the length of comment from 100 to 2000
- Add more response for profile view (including post IDs, role_id, num_comment, num_like_given, num_like_received.

- Return overview of top comments, sorted by likes and created_at

- Return flagged posts and comments of a group, sorted by created_at.

DETAILS:
1/ user/<user_id>/ (Add more information to the response):

   A/ Public Profile View:
![screenshot from 2018-10-25 15-40-44](https://user-images.githubusercontent.com/21095940/47487396-f56a7200-d874-11e8-9775-26e5f84222a7.png)

  B/ Private Profile View:
![screenshot from 2018-10-25 16-33-23](https://user-images.githubusercontent.com/21095940/47487451-0c10c900-d875-11e8-86ee-cf053b9cf9c3.png)

2/ group/<group_id>/posts/ (In each post object, we include a new field "comment" to return top 3 comments)
![screenshot from 2018-10-25 15-38-28](https://user-images.githubusercontent.com/21095940/47487734-90fbe280-d875-11e8-9c05-dbded6cbb117.png)

3/ group/<group_id>/flagged/
![screenshot from 2018-10-25 16-30-22](https://user-images.githubusercontent.com/21095940/47487795-af61de00-d875-11e8-9ec8-25ae83edf3ed.png)


