### PR TITLE
Change superuser's permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ Method | Endpoint | Arguments | Description | Permissions | Return
 `POST` | /user/register/ | * | Create an user using the given arguments. | IsAuthenticated, IsSuperUser | User: *dict*
 `GET` | /user/virtual_users/ | | Get all `virtual` users created by the requester. | IsAuthenticated, IsSuperUser | User: *list*
 `POST` | /user/logout/ | | Disable the requester's token. | IsAuthenticated | {}
-`POST` | /user/update/<user_id/ | * (If update password then need email, oldPassword, password) | Update an user using the given arguments. | IsAuthenticated. The requester must be either the creator of the user or the user himself. | User: *dict*
+`POST` | /user/update/<user_id/ | * (If update password then need `oldPassword` and `password`) | Update an user using the given arguments. | IsAuthenticated. The requester must be either the creator of the user, the user himself or a superuser in a same group. | User: *dict*
 
 ## 2. Users
 
 Method | Endpoint | Arguments | Description | Permissions | Return
 --- | --- | --- | --- | --- | --- |
+`GET` | /users/ | | Get all superusers, all users in the same group or have no groups or created by the requester. | IsAuthenticated, IsSuperUser | User:*list*
 `GET` | /users/non_group/ | | Get all users who are not in any groups. | IsAuthenticated, IsSuperUser | User:*list*
+
 
 ## 3. Post
 
@@ -99,14 +101,18 @@ Method | Endpoint | Arguments | Description | Permissions | Return
 ## 5. Batch
 An URL argument `file_name` is required by [FileUploadParser](https://www.django-rest-framework.org/api-guide/parsers/#fileuploadparser).
 
-A header row is required for the `.csv` files. Empty `is_superuser` and `gender` will default to 0.
+A header row is required for the `.csv` files. The headers allowed include:
+```
+username,email_address,password,realname,gender,description
+```
+ Empty `gender` will default to 0.
 
 An example `.csv` file:
 ```
-username,email_address,password,realname,gender,is_superuser
-chris,chris@email.com,password_for_kris,Christiana Messi,0,0
-james,james@email.com,password_for_kris,Christiana Messi,1,1
-ama,ama@email.com,ama_pwd,Ama Johnson,1,0
+username,email_address,password,realname,gender
+chris,chris@email.com,password_for_kris,Christiana Messi,0
+james,james@email.com,password_for_kris,Christiana Messi,1
+ama,ama@email.com,ama_pwd,Ama Johnson,1
 ```
 
 Method | Endpoint | Arguments | Description | Permissions | Return

--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ ama,ama@email.com,ama_pwd,Ama Johnson,1
 
 Method | Endpoint | Arguments | Description | Permissions | Return
 --- | --- | --- | --- | --- | --- |
-`POST` | /batch/create/user/<file_name>/ | file | Create users from the uploaded file. The UUIDs of created users are returned. | IsAuthenticated, IsSuperUser | {data: {created_users: [], failed_users: []}}
+`POST` | /batch/create/user/<file_name>/ | file | Create users from the uploaded file. The UUIDs of created users are returned. | IsAuthenticated, IsSuperUser | {data: {created_users: []}}

--- a/kidsbook/batch/tests.py
+++ b/kidsbook/batch/tests.py
@@ -17,6 +17,7 @@ class TestBatch(APITestCase):
         self.token = 'Bearer {0}'.format(token.decode('utf-8'))
 
     def test_batch_create(self):
+        prev_count_users = User.objects.count()
         data = {
             'file': (
                 'test_dataset.csv',
@@ -29,11 +30,18 @@ class TestBatch(APITestCase):
 
         response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
         self.assertEqual(202, response.status_code)
+        num_of_created_users = len(response.data.get('data', {}).get('created_users', []))
         self.assertTrue(
-            len(response.data.get('data', {}).get('created_users', [])) == 3
+             num_of_created_users == 3
+        )
+
+        cur_count_users = User.objects.count()
+        self.assertEqual(
+            cur_count_users, prev_count_users + num_of_created_users
         )
 
     def test_batch_create_without_col_is_superuser(self):
+        prev_count_users = User.objects.count()
         data = {
             'file': (
                 'test_dataset.csv',
@@ -47,8 +55,14 @@ class TestBatch(APITestCase):
         response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
 
         self.assertEqual(202, response.status_code)
+        num_of_created_users = len(response.data.get('data', {}).get('created_users', []))
         self.assertTrue(
-            len(response.data.get('data', {}).get('created_users', [])) == 3
+             num_of_created_users == 3
+        )
+
+        cur_count_users = User.objects.count()
+        self.assertEqual(
+            cur_count_users, prev_count_users + num_of_created_users
         )
 
     def test_batch_create_without_token(self):
@@ -70,6 +84,7 @@ class TestBatch(APITestCase):
         self.assertEqual(400, response.status_code)
 
     def test_batch_create_with_failed_users(self):
+        prev_count_users = User.objects.count()
         data = {
             'file': (
                 'test_dataset.csv',
@@ -82,9 +97,6 @@ class TestBatch(APITestCase):
 
         response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
         self.assertEqual(400, response.status_code)
-        self.assertTrue(
-            len(response.data.get('data', {}).get('created_users', [])) == 1
-        )
-        self.assertTrue(
-            len(response.data.get('data', {}).get('failed_users', [])) == 2
-        )
+
+        cur_count_users = User.objects.count()
+        self.assertEqual(cur_count_users, prev_count_users)

--- a/kidsbook/batch/tests.py
+++ b/kidsbook/batch/tests.py
@@ -100,3 +100,27 @@ class TestBatch(APITestCase):
 
         cur_count_users = User.objects.count()
         self.assertEqual(cur_count_users, prev_count_users)
+
+    def test_batch_create_existing_user(self):
+        # Create a normal user
+        username = "chris"
+        email = "chris@email.com"
+        password = "maybeYouRRight"
+        self.user = User.objects.create_user(username=username, email_address=email, password=password)
+
+        prev_count_users = User.objects.count()
+        data = {
+            'file': (
+                'test_dataset.csv',
+                """username,email_address,password,realname,gender,is_superuser
+                chris,chris@email.com,password_for_kris,Christiana Messi,0,0
+                james,james@email.com,password_for_kris,Christiana Messi,1,0
+                ama,ama@email.com,ama_pwd,Ama Johnson,1,0"""
+            )
+        }
+
+        response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
+        self.assertEqual(400, response.status_code)
+
+        cur_count_users = User.objects.count()
+        self.assertEqual(cur_count_users, prev_count_users)

--- a/kidsbook/batch/tests.py
+++ b/kidsbook/batch/tests.py
@@ -22,12 +22,30 @@ class TestBatch(APITestCase):
                 'test_dataset.csv',
                 """username,email_address,password,realname,gender,is_superuser
                 chris,chris@email.com,password_for_kris,Christiana Messi,0,0
-                james,james@email.com,password_for_kris,Christiana Messi,1,1
+                james,james@email.com,password_for_kris,Christiana Messi,1,0
                 ama,ama@email.com,ama_pwd,Ama Johnson,1,0"""
             )
         }
 
         response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
+        self.assertEqual(202, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', {}).get('created_users', [])) == 3
+        )
+
+    def test_batch_create_without_col_is_superuser(self):
+        data = {
+            'file': (
+                'test_dataset.csv',
+                """username,email_address,password,realname,gender
+                chris,chris@email.com,password_for_kris,Christiana Messi,0
+                james,james@email.com,password_for_kris,Christiana Messi,1
+                ama,ama@email.com,ama_pwd,Ama Johnson,1"""
+            )
+        }
+
+        response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
+
         self.assertEqual(202, response.status_code)
         self.assertTrue(
             len(response.data.get('data', {}).get('created_users', [])) == 3
@@ -65,8 +83,8 @@ class TestBatch(APITestCase):
         response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
         self.assertEqual(400, response.status_code)
         self.assertTrue(
-            len(response.data.get('data', {}).get('created_users', [])) == 2
+            len(response.data.get('data', {}).get('created_users', [])) == 1
         )
         self.assertTrue(
-            len(response.data.get('data', {}).get('failed_users', [])) == 1
+            len(response.data.get('data', {}).get('failed_users', [])) == 2
         )

--- a/kidsbook/batch/tests.py
+++ b/kidsbook/batch/tests.py
@@ -124,3 +124,22 @@ class TestBatch(APITestCase):
 
         cur_count_users = User.objects.count()
         self.assertEqual(cur_count_users, prev_count_users)
+
+    def test_batch_create_existing_user_2(self):
+        prev_count_users = User.objects.count()
+        data = {
+            'file': (
+                'test_dataset.csv',
+                """username,email_address,password,realname,gender,is_superuser
+                chris,chris@email.com,password_for_kris,Christiana Messi,0,0
+                james,james@email.com,password_for_kris,Christiana Messi,1,0
+                ama,ama@email.com,ama_pwd,Ama Johnson,1,0"""
+            )
+        }
+        # Create the users twice
+        response_first = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
+        response = self.client.post(self.url + 'create/user/test_dataset.csv/', data=data, HTTP_AUTHORIZATION=self.token)
+        self.assertEqual(400, response.status_code)
+
+        cur_count_users = User.objects.count()
+        self.assertEqual(cur_count_users, prev_count_users + len(response_first.data.get('data', {}).get('created_users', [])))

--- a/kidsbook/batch/views.py
+++ b/kidsbook/batch/views.py
@@ -61,7 +61,6 @@ def create_user_from_list(arr: List[str], mappings: dict):# Careful with the ind
         created_user = User.objects.create_superuser(**user)
     else:
         created_user = User.objects.create_user(**user)
-
     return str(created_user.id)
 
 

--- a/kidsbook/batch/views.py
+++ b/kidsbook/batch/views.py
@@ -6,12 +6,13 @@ from rest_framework.permissions import IsAuthenticated, BasePermission
 from rest_framework.parsers import FileUploadParser
 from csv import reader
 from typing import List
-from django.db import transaction
+from django.db import Error, transaction
 
 from kidsbook.serializers import UserSerializer, GroupSerializer
 from kidsbook.models import Group, GroupMember
 from kidsbook.permissions import IsSuperUser
 User = get_user_model()
+
 
 def read_file_obj_to_list(file_obj) -> List[str]:
     # Remove the wrapper of the request
@@ -90,6 +91,8 @@ def batch_create(request, filename, format=None):
                 created_users.append(
                     create_user_from_list(user, mapping_fields)
                 )
+    except Error as db_err:
+        error = str(db_err)
     except Exception as exc:
         error = str(exc)
 

--- a/kidsbook/group/views.py
+++ b/kidsbook/group/views.py
@@ -107,8 +107,8 @@ def group_member(request, **kargs):
             function_mappings[request.method](new_member, target_group)
 
             return Response({}, status=status.HTTP_202_ACCEPTED)
-    except Exception:
-        pass
+    except Exception as exc:
+        return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
     return Response({'error': 'Bad request.'}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -41,7 +41,6 @@ class UserManager(BaseUserManager):
         self.create_roles()
         if 'username' not in kargs:
             raise ValueError('The given username must be set')
-            # kargs['username'] = 'anonymous'
 
         role = kargs.pop('role', 2)
         password = kargs.pop('password', '12345')
@@ -57,13 +56,9 @@ class UserManager(BaseUserManager):
         #     teacher = User.objects.get(id=kargs['teacher_id'])
         #     user.teacher = teacher
 
-        #print("ABOUT TO SAVE")
-        #print(self._db)
-        try:
-            user.save(using=self._db)
-            #print("HIEU")
-        except Exception as e:
-            print(e)
+        # Don't try-catch this command, as other functions will catch and return the error message
+        user.save(using=self._db)
+
         return user
 
     def create_user(self, **kargs):

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -103,7 +103,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     gender = models.BooleanField(default=False)
     description = models.TextField(default="")
     date_of_birth = models.DateField(null=True)
-    #avatar_url = models.CharField(max_length=65530, null=True)
+    created_at = models.DateTimeField(auto_now_add=True)
     profile_photo = models.ImageField(null=True)
     login_time = models.PositiveIntegerField(default=0)
     screen_time = models.PositiveIntegerField(default=0)
@@ -213,7 +213,7 @@ class Post(models.Model):
     shares = models.ManyToManyField(User, related_name='shares', through='UserSharePost')
     flags = models.ManyToManyField(User, related_name='flags', through='UserFlagPost')
     picture = models.ImageField(null=True)
-    
+
     link = models.URLField(null=True)
     ogp = models.TextField(null=True)
 

--- a/kidsbook/permissions.py
+++ b/kidsbook/permissions.py
@@ -34,6 +34,10 @@ class IsSuperUser(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.user.is_superuser
 
+class isAdmin(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user.role == 0
+
 class IsInGroup(permissions.BasePermission):
     def has_permission(self, request, view):
         # If there are no `pk`

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -23,7 +23,7 @@ User = get_user_model()
 class GroupPostList(generics.ListCreateAPIView):
     queryset = Post.objects.all()
     serializer_class = PostSerializer
-    permission_classes = (IsAuthenticated, IsInGroup)
+    permission_classes = (IsAuthenticated, IsTokenValid, IsInGroup)
 
     def list(self, request, **kwargs):
         try:
@@ -61,7 +61,7 @@ class GroupFlaggedPostList(generics.ListAPIView):
 class PostLike(generics.ListCreateAPIView):
     queryset = UserLikePost.objects.all()
     serializer_class = PostLikeSerializer
-    permission_classes = (IsAuthenticated, HasAccessToPost,)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToPost,)
 
     def list(self, request, **kwargs):
         try:
@@ -80,7 +80,7 @@ class PostLike(generics.ListCreateAPIView):
 class CommentLike(generics.ListCreateAPIView):
     queryset = UserLikeComment.objects.all()
     serializer_class = CommentLikeSerializer
-    permission_classes = (IsAuthenticated, HasAccessToComment)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToComment)
 
     def list(self, request, **kwargs):
         try:
@@ -99,7 +99,7 @@ class CommentLike(generics.ListCreateAPIView):
 class PostFlag(generics.ListCreateAPIView):
     queryset = UserFlagPost.objects.all()
     serializer_class = PostFlagSerializer
-    permission_classes = (IsAuthenticated, HasAccessToPost)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToPost)
 
     def list(self, request, **kwargs):
         try:
@@ -118,7 +118,7 @@ class PostFlag(generics.ListCreateAPIView):
 class CommentFlag(generics.ListCreateAPIView):
     queryset = UserFlagPost.objects.all()
     serializer_class = CommentFlagSerializer
-    permission_classes = (IsAuthenticated, HasAccessToComment)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToComment)
 
     def list(self, request, **kwargs):
         try:
@@ -137,7 +137,7 @@ class CommentFlag(generics.ListCreateAPIView):
 class PostShare(generics.ListCreateAPIView):
     queryset = UserSharePost.objects.all()
     serializer_class = PostShareSerializer
-    permission_classes = (IsAuthenticated, HasAccessToPost,)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToPost,)
 
     def list(self, request, **kwargs):
         try:
@@ -156,7 +156,7 @@ class PostShare(generics.ListCreateAPIView):
 class PostDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Post.objects.all()
     serializer_class = PostSerializer
-    permission_classes = (IsAuthenticated, HasAccessToPost)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToPost)
 
     def get(self, request, *args, **kwargs):
         try:
@@ -179,7 +179,7 @@ class PostDetail(generics.RetrieveUpdateDestroyAPIView):
 class PostCommentList(generics.ListCreateAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
-    permission_classes = (IsAuthenticated, HasAccessToPost)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToPost)
 
     def list(self, request, **kwargs):
         try:
@@ -198,7 +198,7 @@ class PostCommentList(generics.ListCreateAPIView):
 class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
-    permission_classes = (IsAuthenticated, HasAccessToComment)
+    permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToComment)
 
     def get(self, request, *args, **kwargs):
         try:

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -11,7 +11,7 @@ import json
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'username', 'email_address', 'is_active', 'profile_photo', 'is_superuser', 'description', "realname", 'group_users')
+        fields = ('id', 'username', 'email_address', 'is_active', 'profile_photo', 'is_superuser', 'description', "realname", 'group_users', 'created_at')
         depth = 1
 
 # This class is for public profile

--- a/kidsbook/user/tests.py
+++ b/kidsbook/user/tests.py
@@ -371,7 +371,7 @@ class TestUserUpdate(APITestCase):
         response = self.client.post(self.update_url, data=data, HTTP_AUTHORIZATION=token)
         self.assertEqual(405, response.status_code)
 
-    def test_update_by_non_creator(self):
+    def test_update_in_no_groups_by_non_creator(self):
         # Create a random user
         username = "chris"
         email = "chris@snow.com"
@@ -384,7 +384,10 @@ class TestUserUpdate(APITestCase):
             'description': 'Corki'
         }
         response = self.client.post(self.update_url, data=data, HTTP_AUTHORIZATION=token)
-        self.assertEqual(405, response.status_code)
+        self.assertEqual(202, response.status_code)
+
+    #def test_update_in_a_diff_group_by_non_creator(self):
+
 
 def TestUserPost(self):
     def setUp(self):

--- a/kidsbook/user/tests.py
+++ b/kidsbook/user/tests.py
@@ -329,7 +329,7 @@ class TestUserUpdate(APITestCase):
                 'description': 'Corki',
                 "profile_photo": pic}
             response = self.client.post(self.update_url, request_changes, HTTP_AUTHORIZATION=token)
-            self.assertTrue(202, response.status_code)
+            self.assertEqual(202, response.status_code)
 
         cur_state = self.client.get("{}{}/".format(self.url, self.modify_user.id), HTTP_AUTHORIZATION=token).data.get('data', {})
         self.assertTrue(
@@ -431,13 +431,45 @@ class TestUserUpdate(APITestCase):
                 'description': 'Corki',
                 "profile_photo": pic}
             response = self.client.post("{}update/{}/".format(self.url, self.creator.id), request_changes, HTTP_AUTHORIZATION=token)
-            self.assertTrue(202, response.status_code)
+            self.assertEqual(202, response.status_code)
 
         cur_state = self.client.get("{}{}/".format(self.url, self.creator.id), HTTP_AUTHORIZATION=token).data.get('data', {})
 
         self.assertTrue(
             self.changes_reflect_in_response(request_changes, previous_state_of_user, cur_state)
         )
+
+    def test_update_superuser_password_by_himself(self):
+        token = self.get_token(self.creator)
+        previous_state_of_user = self.client.get("{}{}/".format(self.url, self.creator.id), HTTP_AUTHORIZATION=token).data.get('data', {})
+
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../backend/media/picture.png'), 'rb') as pic:
+            request_changes = {
+                'username': 'Not_doggo',
+                'description': 'Corki',
+                "profile_photo": pic,
+                'password': 'new_pass',
+                'oldPassword': self.password}
+            response = self.client.post("{}update/{}/".format(self.url, self.creator.id), request_changes, HTTP_AUTHORIZATION=token)
+            self.assertEqual(202, response.status_code)
+
+        cur_state = self.client.get("{}{}/".format(self.url, self.creator.id), HTTP_AUTHORIZATION=token).data.get('data', {})
+
+        self.assertTrue(
+            self.changes_reflect_in_response(request_changes, previous_state_of_user, cur_state)
+        )
+
+    def test_update_superuser_password_without_oldpassword_by_himself(self):
+        token = self.get_token(self.creator)
+        
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../backend/media/picture.png'), 'rb') as pic:
+            request_changes = {
+                'username': 'Not_doggo',
+                'description': 'Corki',
+                "profile_photo": pic,
+                'password': 'new_pass'}
+            response = self.client.post("{}update/{}/".format(self.url, self.creator.id), request_changes, HTTP_AUTHORIZATION=token)
+            self.assertEqual(405, response.status_code)
 
 
 class TestUpdateVirtualUser(APITestCase):

--- a/kidsbook/user/views.py
+++ b/kidsbook/user/views.py
@@ -122,7 +122,10 @@ class Register(APIView):
             except Exception:
                 return Response({'error': "Invalid teacher's ID."}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-        user = mapping_create[user_role](**request_data)
+        try:
+            user = mapping_create[user_role](**request_data)
+        except Exception as exc:
+            Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
         # group = Group.objects.get(id=request.data['group_id'])
         # group.add_member(user)

--- a/kidsbook/user/views.py
+++ b/kidsbook/user/views.py
@@ -168,8 +168,8 @@ class Update(generics.RetrieveUpdateDestroyAPIView):
         #     return Response({'error': 'Only the creator and this user can edit.'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
         target_user = User.objects.get(id=target_user_id)
-        if target_user.role.id == 1:
-            return Response({'error': 'A superuser can only be modified by Admin.'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+        if target_user.role.id <= 1 and target_user.id != request.user.id:
+            return Response({'error': 'A superuser can only be modified by Admin or himself.'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
         if request.user.role.id == 2 and target_user.id != request.user.id:
             return Response({'error': 'A student cannot modify another user.'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/kidsbook/users/urls.py
+++ b/kidsbook/users/urls.py
@@ -3,6 +3,7 @@ from rest_framework.urlpatterns import format_suffix_patterns
 from kidsbook.users import views
 
 urlpatterns = [
+    path('', views.users_allowed_to_be_discovered),
     path('non_group/', views.non_group)
 ]
 

--- a/kidsbook/users/views.py
+++ b/kidsbook/users/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated, BasePermission
 from rest_framework import status, generics
 from uuid import UUID
+from itertools import chain
 
 #from kidsbook.group.serializers import GroupSerializer
 from kidsbook.serializers import *
@@ -39,3 +40,38 @@ def non_group(request):
     if request.method in function_mappings:
         return function_mappings[request.method](request)
     return Response({'error': 'Bad request.'}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['GET'])
+@permission_classes((IsAuthenticated, IsTokenValid, IsSuperUser))
+def users_allowed_to_be_discovered(request):
+    """Return all superusers, all users in the same group or have no groups or created by the requester."""
+
+    try:
+        # USERS HAVE NO GROUPS
+        all_users = iter(User.objects.all())
+        users_not_in_any_groups = list(filter(
+            lambda user: not GroupMember.objects.filter(user_id=user.id).exists(), all_users
+        ))
+
+        # ALL SUPER USERS
+        all_superusers = User.objects.filter(role=1).exclude(id=request.user.id)
+
+        # ALL USERS IN SAME GROUPS
+        group_ids = GroupMember.objects.filter(user_id=request.user.id).distinct().values_list('group_id', flat=True)
+        user_ids_in_same_groups = GroupMember.objects.filter(group_id__in=group_ids).distinct().values_list('user_id', flat=True)
+        all_users_in_same_groups = User.objects.filter(id__in=user_ids_in_same_groups).distinct().exclude(id=request.user.id)
+
+        # CREATED BY REQUESTER
+        users_created_by_requester = User.objects.filter(teacher=request.user)
+
+        # Merge and serializer
+        result_list = list(set(chain(users_not_in_any_groups, all_superusers, all_users_in_same_groups, users_created_by_requester)))
+        result_list = sorted(result_list, key=lambda instance: instance.created_at, reverse=True)
+        serializer = UserSerializer(result_list, many=True)
+
+        return Response({'data': serializer.data})
+    except Exception as exc:
+        Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+    return Response(status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Follow the request to change permissions #42 .
`README.md` and tests are updated.


#### 1. Endpoint `/user/update/<user_id/`
-  It now doesn't require a field `email` to change the `password`. 
- `Superuser` now doesn't require field `oldPassword` to change the `password`. This is to allow `Superuser` to reset an user's password.
- A Superuser is allowed to update:
    - Himself
    - Users have no groups
    - Users and Virtual users in the same groups as the requester
    - Users and Virtual users created by the requester

#### 2. Endpoint `batch/create/user/<filename>/`
- Allowed fields now are `username,email_address,password,realname,gender,description`.
- The response is now:
```
{
    'error': "",     // This only presents when `failed_users` is not empty
    'data': {
        'created_users': List[ User: *dict* ],
        'failed_users': List[ User: *dict* ]
    }
}
```

#### 3. *New* Endpoint `/users/`
- Return all discoverable users by the current `superuser`:
    - All Superusers
    - Users have no groups
    -  Users and Virtual users in the same groups as the requester
    - Users and Virtual users created by the requester

#### 4. Model `User`
- Add a new field `created_at`.


