### PR TITLE
Fix flagging bug that disallows flagging a post after flagging 2 of i…

### DIFF
--- a/kidsbook/post/tests.py
+++ b/kidsbook/post/tests.py
@@ -357,8 +357,6 @@ class TestPost(APITestCase):
         url = "{}/post/{}/flags/".format(url_prefix, self.post.id)
         flag_status = "IN_PROGRESS"
         response = self.client.post(url, {"status": flag_status}, HTTP_AUTHORIZATION=self.creator_token)
-        # with open('output.txt', 'w') as out_f:
-        #     out_f.write(str(response.data))
 
         self.assertEqual(202, response.status_code)
 

--- a/kidsbook/post/tests.py
+++ b/kidsbook/post/tests.py
@@ -48,6 +48,14 @@ class TestPost(APITestCase):
             creator=self.creator
         )
 
+        # Create another comment
+        self.another_comment = Comment.objects.create_comment(
+            content='not okay at all',
+            post=self.post,
+            creator=self.creator
+        )
+
+
     def changes_reflect_in_response(self, request_changes, previous_state, current_state):
         difference = { k : current_state[k] for k in set(current_state) - set(previous_state) }
 
@@ -329,11 +337,31 @@ class TestPost(APITestCase):
         response = self.client.post(url, {"status": flag_status}, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(202, response.status_code)
         flag_id = response.data.get('data', {}).get('id', '')
-        
+
         self.assertTrue(
             UserFlagPost.objects.filter(id=flag_id).exists()
             and (UserFlagPost.objects.get(id=flag_id).status) == flag_status
         )
+
+    def test_flag_2_comments_and_post(self):
+        url = "{}/comment/{}/flags/".format(url_prefix, self.comment.id)
+        flag_status = "IN_PROGRESS"
+        response = self.client.post(url, {"status": flag_status}, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(202, response.status_code)
+
+        url = "{}/comment/{}/flags/".format(url_prefix, self.another_comment.id)
+        flag_status = "IN_PROGRESS"
+        response = self.client.post(url, {"status": flag_status}, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(202, response.status_code)
+
+        url = "{}/post/{}/flags/".format(url_prefix, self.post.id)
+        flag_status = "IN_PROGRESS"
+        response = self.client.post(url, {"status": flag_status}, HTTP_AUTHORIZATION=self.creator_token)
+        # with open('output.txt', 'w') as out_f:
+        #     out_f.write(str(response.data))
+
+        self.assertEqual(202, response.status_code)
+
 
     def test_flag_comment_by_non_member(self):
         url = "{}/comment/{}/flags/".format(url_prefix, self.comment.id)

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -68,7 +68,7 @@ class GroupPostList(generics.ListCreateAPIView):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
         except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class GroupFlaggedList(generics.ListAPIView):
     queryset = Post.objects.all()
@@ -94,7 +94,7 @@ class GroupFlaggedList(generics.ListAPIView):
         for flag in response_data:
             flag['user_id'] = flag['user']['id']
             flag['user_photo'] = flag['user']['profile_photo']
-            flag['user_name'] = flag['user']['realname']
+            flag['user_name'] = flag['user']['username']
             flag.pop('user', None)
             if(flag['comment'] == None):
                 flag.pop('comment', None)
@@ -120,8 +120,8 @@ class PostLike(generics.ListCreateAPIView):
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class CommentLike(generics.ListCreateAPIView):
     queryset = UserLikeComment.objects.all()
@@ -131,16 +131,16 @@ class CommentLike(generics.ListCreateAPIView):
     def list(self, request, **kwargs):
         try:
             queryset = self.get_queryset().filter(comment = Comment.objects.get(id=kwargs['pk']))
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         serializer = CommentLikeSerializer(queryset, many=True)
         return Response({'data': serializer.data})
 
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class PostFlag(generics.ListCreateAPIView):
     queryset = UserFlagPost.objects.all()
@@ -150,16 +150,16 @@ class PostFlag(generics.ListCreateAPIView):
     def list(self, request, **kwargs):
         try:
             queryset = self.get_queryset().filter(post = Post.objects.get(id=kwargs['pk']))
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         serializer = PostFlagSerializer(queryset, many=True)
         return Response({'data': serializer.data})
 
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class CommentFlag(generics.ListCreateAPIView):
     queryset = UserFlagPost.objects.all()
@@ -169,16 +169,16 @@ class CommentFlag(generics.ListCreateAPIView):
     def list(self, request, **kwargs):
         try:
             queryset = self.get_queryset().filter(comment = Comment.objects.get(id=kwargs['pk']))
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         serializer = CommentFlagSerializer(queryset, many=True)
         return Response({'data': serializer.data})
 
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class PostShare(generics.ListCreateAPIView):
     queryset = UserSharePost.objects.all()
@@ -188,16 +188,16 @@ class PostShare(generics.ListCreateAPIView):
     def list(self, request, **kwargs):
         try:
             queryset = self.get_queryset().filter(post = Post.objects.get(id=kwargs['pk']))
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         serializer = PostShareSerializer(queryset, many=True)
         return Response({'data': serializer.data})
 
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class PostDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Post.objects.all()
@@ -213,14 +213,14 @@ class PostDetail(generics.RetrieveUpdateDestroyAPIView):
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.update(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, *args, **kwargs):
         try:
             return Response({'data': self.destroy(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class PostCommentList(generics.ListCreateAPIView):
     queryset = Comment.objects.all()
@@ -230,16 +230,16 @@ class PostCommentList(generics.ListCreateAPIView):
     def list(self, request, **kwargs):
         try:
             queryset = self.get_queryset().filter(post=Post.objects.get(id=kwargs['pk']))
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         serializer = CommentSerializer(queryset, many=True)
         return Response({'data': serializer.data})
 
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Comment.objects.all()
@@ -249,20 +249,20 @@ class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
     def get(self, request, *args, **kwargs):
         try:
             return Response({'data': self.retrieve(request, *args, **kwargs).data})
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.update(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, *args, **kwargs):
         try:
             return Response({'data': self.destroy(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class UserList(generics.ListCreateAPIView):
     queryset = User.objects.all()

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -67,7 +67,7 @@ class GroupPostList(generics.ListCreateAPIView):
     def post(self, request, *args, **kwargs):
         try:
             return Response({'data': self.create(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
-        except Exception:
+        except Exception as exc:
             return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
 class GroupFlaggedList(generics.ListAPIView):

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -80,8 +80,10 @@ class PostFlagSerializer(serializers.ModelSerializer):
 
     def create(self, data):
         post = Post.objects.get(id=self.context['view'].kwargs.get("pk"))
+
         current_user = self.context['request'].user
-        new_obj, created = UserFlagPost.objects.update_or_create(post=post, user=current_user, defaults={'status': data["status"], 'comment': None})
+        new_obj, created = UserFlagPost.objects.update_or_create(post=post, user=current_user, comment__isnull=True, defaults={'status': data["status"], 'comment': None})
+
         return new_obj
 
 class CommentFlagSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
1. Fix a bug in `PostFlagSerializer`: 
    - While checking if a flag for the post exists, the serializer doesn't for field `comment` but only `post` and `user`, causing an error of finding more than 1 post.
    - A test for this case is added.
2. Return the error messages for all `400` responses in `post`.
3. Change `user_name` to use `username` instead of `realname`, in `GroupFlaggedList`.
