### PR TITLE
Change implementation of delete post/comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,5 +178,5 @@ db.sqlite3
 **/media/portrait/*/*
 **/media/document_thumbnails/*
 .DS_Store
-
+*.txt
 **/migrations/*

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Method | Endpoint | Arguments | Description | Permissions | Return
 --- | --- | --- | --- | --- | --- |
 `GET` | /user/<user_id>/ | | Get the user's information. | IsAuthenticated | User: *dict*
 `GET` | /user/<user_id>/groups/ | | Get all the groups the user is in. | IsAuthenticated | User: *list*
-`GET` | /user/posts/ | | Get all posts created by the current user. | IsAuthenticated | User: *list*
+`GET` | /user/<user_id>/posts/ | | Get all posts created by the user. | IsAuthenticated | User: *list*
 `POST` | /user/login/ | email_address:*str*, password:*str* | Return an authentication token for the user. | AllowAny | {data: {id: '', token: ''}}
 `POST` | /user/login_as_virtual/ | email_address:*str* | Return an authentication for the `virtual` user. | IsAuthenticated, IsSuperUser | {data: {name: '', token: ''}}
 `POST` | /user/register/ | * | Create an user using the given arguments. | IsAuthenticated, IsSuperUser | User: *dict*
@@ -64,23 +64,25 @@ Method | Endpoint | Arguments | Description | Permissions | Return
 
 Method | Endpoint | Arguments | Description | Permissions | Return
 --- | --- | --- | --- | --- | --- |
-`GET` | /group/<group_id>/posts/ | | Get all posts in the group. | IsAuthenticated, IsInGroup | Post: *list*
+`GET` | /group/<group_id>/posts/ | | Get all posts in the group (exclude deleted ones). | IsAuthenticated, IsInGroup | Post: *list*
+`GET` | /group/<group_id>/posts/?all=<bool> | | Get all posts in the group (include deleted ones). `bool` is case-insensitive. | IsAuthenticated, IsInGroup, IsSuperUser | Post: *list*
 `POST` | /group/<group_id>/posts/ | * | Create a post in the group. | IsAuthenticated, IsInGroup | Post: *dict*
-`POST` | group/<group_id>/flagged/ | Get all flagged posts in the group | IsAuthenticated, IsInGroup, IsSuperUser | Post: *list*
+`GET` | group/<group_id>/flagged/ | Get all flagged posts in the group. | IsAuthenticated, IsInGroup, IsSuperUser | Post: *list*
 `GET` | /post/<post_id>/ | | Get post's details by ID. | IsAuthenticated, HasAccessToPost | Post: *dict*
 `POST` | /post/<post_id>/ | * | Update the post. | IsAuthenticated, HasAccessToPost | Post: *dict*
-`DELETE` | /post/<post_id>/ | * | Delete the post. | IsAuthenticated, HasAccessToPost | {}
+`DELETE` | /post/<post_id>/ | * | Set the flag `is_deleted` of the post to `True`. | IsAuthenticated, HasAccessToPost | {}
 `GET` | /post/<post_id>/likes/ | | Get all likes/dislikes of the post. | IsAuthenticated, HasAccessToPost | UserLikePost: *list*
 `POST` | /post/<post_id>/likes/ | like_or_dislike: *bool* | Like/dislike the post. | IsAuthenticated, HasAccessToPost | UserLikePost: *dict*
 `GET` | /post/<post_id>/shares/ | | Get all shares of the post. | IsAuthenticated, HasAccessToPost | UserSharePost: *list*
 `POST` | /post/<post_id>/shares/ | | User `shares` the post.  | IsAuthenticated, HasAccessToPost | UserSharePost: *dict*
-`GET` | /post/<post_id>/comments/ | | Get all comments of the post. | IsAuthenticated, HasAccessToPost | Comment: *list*
+`GET` | /post/<post_id>/comments/ | | Get all comments of the post (exclude deleted ones). | IsAuthenticated, HasAccessToPost | Comment: *list*
+`GET` | /post/<post_id>/comments/?all=<bool> | | Get all comments of the post (include deleted ones). `bool` is case-insensitive.. | IsAuthenticated, HasAccessToPost, IsSuperUser | Comment: *list*
 `POST` | /post/<post_id>/comments/ | content:*str* | Create a comment for the post. | IsAuthenticated, HasAccessToPost | Comment: *dict*
 `GET` | /post/<post_id>/flags/ | | Get all flags of the post. | IsAuthenticated, HasAccessToPost | UserFlagPost: *list*
 `POST` | /post/<post_id>/flags/ | status:*str* | Create a flag for the post. | IsAuthenticated, HasAccessToPost | UserFlagPost: *dict*
 `GET` | /comment/<comment_id>/ | | Get comment's details by ID. | IsAuthenticated, HasAccessToComment | Comment: *dict*
 `POST` | /comment/<comment_id>/ | content:*str* | Update the comment. | IsAuthenticated, HasAccessToComment | Comment: *dict*
-`DELETE` | /comment/<comment_id>/ | | Delete the comment. | IsAuthenticated, HasAccessToComment | {}
+`DELETE` | /comment/<comment_id>/ | | Set the flag `is_deleted` of the comment to `True`. | IsAuthenticated, HasAccessToComment | {}
 `GET` | /comment/<comment_id>/likes/ | | Get the likes/dislikes of the comment. | IsAuthenticated, HasAccessToComment | UserLikeComment: *list*
 `POST` | /comment/<comment_id>/likes/ | like_or_dislike:*bool* | User likes/dislikes a comment. | IsAuthenticated, HasAccessToComment | UserLikeComment: *dict*
 `GET` | /comment/<comment_id>/flags/ | | Get the flags of the comment. | IsAuthenticated, HasAccessToComment | UserFlagPost: *list*

--- a/kidsbook/group/views.py
+++ b/kidsbook/group/views.py
@@ -146,7 +146,7 @@ def update_group_detail(request, kargs):
 
         group_fields = set(Group.__dict__.keys())
         if request.user.id != group.creator.id:
-            return Response({'error': "Only the creator can modify group's details."}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({'error': "Only the creator can modify group's details."}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
         for attr, value in iter(request.data.dict().items()):
             if attr in group_fields:

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -208,9 +208,9 @@ class Post(models.Model):
     shares = models.ManyToManyField(User, related_name='shares', through='UserSharePost')
     flags = models.ManyToManyField(User, related_name='flags', through='UserFlagPost')
     picture = models.ImageField(null=True)
-
     link = models.URLField(null=True)
     ogp = models.TextField(null=True)
+    is_deleted = models.BooleanField(default=False)
 
     REQUIRED_FIELDS = ["content"]
 
@@ -252,7 +252,8 @@ class Comment(models.Model):
     post = models.ForeignKey(Post, related_name='comments_post', on_delete=models.CASCADE, default=uuid.uuid4)
     creator = models.ForeignKey(User, related_name='comment_owner', on_delete=models.CASCADE, default=uuid.uuid4)
     likes = models.ManyToManyField(User, related_name='comment_likers', through='UserLikeComment')
-
+    is_deleted = models.BooleanField(default=False)
+    
     REQUIRED_FIELDS = ['post', 'creator', 'content']
 
     # use_in_migrations = True

--- a/kidsbook/post/tests.py
+++ b/kidsbook/post/tests.py
@@ -142,6 +142,27 @@ class TestPost(APITestCase):
             len(response.data.get('data', [])) == 1
         )
 
+    def test_get_posts_in_group_exclude_deleted_comments_in_top_3(self):
+        # Delete a comment
+        url = "{}/comment/{}/".format(url_prefix, self.another_comment.id)
+        self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/group/{}/posts/".format(url_prefix, self.group_id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.member_token)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 2
+        )
+
+        second_post = response.data.get('data', [])[1]
+        comments = second_post.get('comments', [])
+        self.assertTrue(
+            len(comments) == 1
+        )
+        self.assertTrue(
+            comments[0].get('content') == 'OKAY'
+        )
+
     def test_get_all_posts_in_group_exclude_deleted_with_all(self):
         # Delete a post
         url = "{}/post/{}/".format(url_prefix, self.post2.id)
@@ -276,11 +297,6 @@ class TestPost(APITestCase):
         self.assertTrue(
             len(response.data.get('data', [])) == 1
         )
-
-
-
-
-
 
     def test_create_comment_of_post(self):
         url = "{}/post/{}/comments/".format(url_prefix, self.post.id)

--- a/kidsbook/post/tests.py
+++ b/kidsbook/post/tests.py
@@ -24,19 +24,34 @@ class TestPost(APITestCase):
         self.username = "hey"
         self.email = "kid@s.sss"
         self.password = "want_some_cookies?"
-        self.member = User.objects.create_user(username=self.username, email_address=self.email, password=self.password)
-        token = generate_token(self.member)
+        self.user = User.objects.create_user(username=self.username, email_address=self.email, password=self.password)
+        token = generate_token(self.user)
         self.user_token = 'Bearer {0}'.format(token.decode('utf-8'))
+
+        # Member
+        username = "not_hey"
+        email = "not_kid@s.sss"
+        password = "want_some_cookies?"
+        member = User.objects.create_user(username=username, email_address=email, password=password)
+        token = generate_token(member)
+        self.member_token = 'Bearer {0}'.format(token.decode('utf-8'))
 
         # Create a Group
         response = self.client.post(url_prefix + '/group/', {"name": "testing group"}, HTTP_AUTHORIZATION=self.creator_token)
         self.group_id = response.data.get('data', {}).get('id', '')
+        Group.objects.get(id=self.group_id).add_member(member)
 
         #self.url = "{}/group/{}/".format(url_prefix, self.group_id)
 
         # Create a post
         self.post = Post.objects.create_post(
             content='Need someone to eat lunch at pgp?',
+            creator=self.creator,
+            group=Group.objects.get(id=self.group_id)
+        )
+
+        self.post2 = Post.objects.create_post(
+            content='Another post',
             creator=self.creator,
             group=Group.objects.get(id=self.group_id)
         )
@@ -99,6 +114,57 @@ class TestPost(APITestCase):
         url = "{}/group/{}/posts/".format(url_prefix, self.group_id)
         response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 2
+        )
+
+    def test_get_all_posts_in_group_include_deleted_with_all(self):
+        # Delete a post
+        url = "{}/post/{}/".format(url_prefix, self.post2.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/group/{}/posts/?all=true".format(url_prefix, self.group_id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 2
+        )
+
+    def test_get_all_posts_in_group_include_deleted_with_all_by_non_superuser(self):
+        # Delete a post
+        url = "{}/post/{}/".format(url_prefix, self.post2.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/group/{}/posts/?all=true".format(url_prefix, self.group_id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.member_token)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 1
+        )
+
+    def test_get_all_posts_in_group_exclude_deleted_with_all(self):
+        # Delete a post
+        url = "{}/post/{}/".format(url_prefix, self.post2.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/group/{}/posts/?all=false".format(url_prefix, self.group_id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 1
+        )
+
+    def test_get_all_posts_in_group_exclude_deleted(self):
+        # Delete a post
+        url = "{}/post/{}/".format(url_prefix, self.post2.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/group/{}/posts/".format(url_prefix, self.group_id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 1
+        )
 
     def test_get_all_post_in_group_by_non_member(self):
         url = "{}/group/{}/posts/".format(url_prefix, self.group_id)
@@ -156,6 +222,65 @@ class TestPost(APITestCase):
         url = "{}/post/{}/comments/".format(url_prefix, self.post.id)
         response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 2
+        )
+
+    def test_get_all_comments_include_deleted(self):
+        # Delete a comment
+        url = "{}/comment/{}/".format(url_prefix, self.comment.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/post/{}/comments/?all=TRUE".format(url_prefix, self.post.id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(200, response.status_code)
+
+        self.assertTrue(
+            len(response.data.get('data', [])) == 2
+        )
+
+    def test_get_all_comments_include_deleted_by_non_superuser(self):
+        # Delete a comment
+        url = "{}/comment/{}/".format(url_prefix, self.comment.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/post/{}/comments/?all=TRUE".format(url_prefix, self.post.id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.member_token)
+        self.assertEqual(200, response.status_code)
+        self.assertTrue(
+            len(response.data.get('data', [])) == 1
+        )
+
+    def test_get_all_comments_of_post_exclude_deleted(self):
+        # Delete a comment
+        url = "{}/comment/{}/".format(url_prefix, self.comment.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/post/{}/comments/".format(url_prefix, self.post.id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(200, response.status_code)
+
+        self.assertTrue(
+            len(response.data.get('data', [])) == 1
+        )
+
+    def test_get_all_comments_of_post_exclude_deleted_by_member_non_superuser(self):
+        # Delete a comment
+        url = "{}/comment/{}/".format(url_prefix, self.comment.id)
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+
+        url = "{}/post/{}/comments/".format(url_prefix, self.post.id)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.member_token)
+        self.assertEqual(200, response.status_code)
+
+        self.assertTrue(
+            len(response.data.get('data', [])) == 1
+        )
+
+
+
+
+
 
     def test_create_comment_of_post(self):
         url = "{}/post/{}/comments/".format(url_prefix, self.post.id)
@@ -376,6 +501,19 @@ class TestPost(APITestCase):
         response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(200, response.status_code)
 
+    def test_get_deleted_comment_by_superuser(self):
+        url = "{}/comment/{}/".format(url_prefix, self.comment.id)
+        self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token)
+        self.assertEqual(200, response.status_code)
+
+    def test_get_deleted_comment_by_member_non_superuser(self):
+        url = "{}/comment/{}/".format(url_prefix, self.comment.id)
+        self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.member_token)
+
+        self.assertEqual(405, response.status_code)
+
     def test_update_comment_by_id(self):
         url = "{}/comment/{}/".format(url_prefix, self.comment.id)
         prev_state = self.client.get(url, HTTP_AUTHORIZATION=self.creator_token).data.get('data', {})
@@ -414,8 +552,13 @@ class TestPost(APITestCase):
         url = "{}/comment/{}/".format(url_prefix, self.comment.id)
         response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(202, response.status_code)
-        self.assertFalse(
+
+        # Delete is just to set the flag `is_deleted` to True
+        self.assertTrue(
             Comment.objects.filter(id=self.comment.id).exists()
+        )
+        self.assertTrue(
+            Comment.objects.get(id=self.comment.id).is_deleted
         )
 
     def test_delete_comment_by_non_member(self):
@@ -432,6 +575,14 @@ class TestPost(APITestCase):
         url = "{}/post/{}/".format(url_prefix, self.post.id)
         response = self.client.delete(url, HTTP_AUTHORIZATION=self.creator_token)
         self.assertEqual(202, response.status_code)
+
+        # Delete is just to set the flag `is_deleted` of the post to True
+        self.assertTrue(
+            Post.objects.filter(id=self.post.id).exists()
+        )
+        self.assertTrue(
+            Post.objects.get(id=self.post.id).is_deleted
+        )
 
     def test_delete_post_by_non_creator(self):
         url = "{}/post/{}/".format(url_prefix, self.post.id)

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -43,7 +43,12 @@ class GroupPostList(generics.ListCreateAPIView):
             queryset = queryset.order_by('-created_at')
         except Exception as e:
             return Response(status=status.HTTP_400_BAD_REQUEST)
-        serializer = PostSerializer(queryset, many=True)
+
+        # Change the Serializer depends on the role of requester
+        if request.user.role.id <= 1:
+            serializer = PostSuperuserSerializer(queryset, many=True)
+        else:
+            serializer = PostSerializer(queryset, many=True)
         response_data = serializer.data.copy()
 
         really_likes = UserLikeComment.objects.all().filter(like_or_dislike=True)
@@ -280,7 +285,11 @@ class PostCommentList(generics.ListCreateAPIView):
         except Exception as exc:
             return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
-        serializer = CommentSerializer(queryset, many=True)
+        if request.user.role.id <= 1:
+            serializer = CommentSuperuserSerializer(queryset, many=True)
+        else:
+            serializer = CommentSerializer(queryset, many=True)
+
         for comment in serializer.data:
             comment['like_count'] = len(comment['likes'])
             comment['likers'] = [x['id'] for x in comment['likes']]

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -59,7 +59,7 @@ class GroupPostList(generics.ListCreateAPIView):
             likes = PostLikeSerializer(queryset, many=True)
             post['likes_list'] = likes.data.copy()
 
-            queryset = Comment.objects.all().filter(post=Post.objects.get(id=post['id']))
+            queryset = Comment.objects.all().filter(post=Post.objects.get(id=post['id'])).exclude(is_deleted=True)
             queryset.query.group_by = ['id']
             # queryset = queryset.annotate(
             #     like_count=Sum(

--- a/kidsbook/post/views.py
+++ b/kidsbook/post/views.py
@@ -29,8 +29,18 @@ class GroupPostList(generics.ListCreateAPIView):
 
     def list(self, request, **kwargs):
         try:
-            queryset = self.get_queryset().filter(group = Group.objects.get(id=kwargs['pk'])).order_by('-created_at')
+            # Get all posts in the group
+            queryset = self.get_queryset().filter(group = Group.objects.get(id=kwargs['pk']))
 
+            if ('all' in request.query_params
+                    and str(request.query_params.get('all', 'false')).lower() == 'true'
+                    and request.user.role.id <= 1
+                    ):
+                pass
+            else:
+                queryset = queryset.exclude(is_deleted=True)
+
+            queryset = queryset.order_by('-created_at')
         except Exception as e:
             return Response(status=status.HTTP_400_BAD_REQUEST)
         serializer = PostSerializer(queryset, many=True)
@@ -217,10 +227,20 @@ class PostDetail(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToPost)
 
     def get(self, request, *args, **kwargs):
+        post_id = kwargs.get('pk', None)
+
+        if post_id and not Post.objects.filter(id=post_id).exists():
+            return Response({'error': 'Post not found'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
         try:
-            return Response({'data': self.retrieve(request, *args, **kwargs).data})
-        except Exception:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+            post = Post.objects.get(id=post_id)
+            if post.is_deleted and not request.user.is_superuser:
+                return Response({'error': 'Post not found'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+            serializer = PostSerializer(post)
+            return Response({'data': serializer.data})
+        except Exception as exc:
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
     def post(self, request, *args, **kwargs):
         try:
@@ -230,7 +250,11 @@ class PostDetail(generics.RetrieveUpdateDestroyAPIView):
 
     def delete(self, request, *args, **kwargs):
         try:
-            return Response({'data': self.destroy(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
+            post_id = kwargs.get('pk', '')
+            post_to_delete = Post.objects.get(id=post_id)
+            post_to_delete.is_deleted = True
+            post_to_delete.save()
+            return Response({}, status=status.HTTP_202_ACCEPTED)
         except Exception as exc:
             return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -241,9 +265,21 @@ class PostCommentList(generics.ListCreateAPIView):
 
     def list(self, request, **kwargs):
         try:
+            # Get all comments in the post
             queryset = self.get_queryset().filter(post=Post.objects.get(id=kwargs['pk']))
+
+            if ('all' in request.query_params
+                    and str(request.query_params.get('all', 'false')).lower() == 'true'
+                    and request.user.role.id <= 1
+                    ):
+                pass
+            else:
+                queryset = queryset.exclude(is_deleted=True)
+
+            queryset = queryset.order_by('-created_at')
         except Exception as exc:
             return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
         serializer = CommentSerializer(queryset, many=True)
         for comment in serializer.data:
             comment['like_count'] = len(comment['likes'])
@@ -263,8 +299,18 @@ class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = (IsAuthenticated, IsTokenValid, HasAccessToComment)
 
     def get(self, request, *args, **kwargs):
+        comment_id = kwargs.get('pk', None)
+
+        if comment_id and not Comment.objects.filter(id=comment_id).exists():
+            return Response({'error': 'Comment not found'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
         try:
-            return Response({'data': self.retrieve(request, *args, **kwargs).data})
+            comment = Comment.objects.get(id=comment_id)
+            if comment.is_deleted and not request.user.is_superuser:
+                return Response({'error': 'Comment not found'}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+            serializer = CommentSerializer(comment)
+            return Response({'data': serializer.data})
         except Exception as exc:
             return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -276,7 +322,12 @@ class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
 
     def delete(self, request, *args, **kwargs):
         try:
-            return Response({'data': self.destroy(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
+            comment_id = kwargs.get('pk', '')
+            comment_to_delete = Comment.objects.get(id=comment_id)
+            comment_to_delete.is_deleted = True
+            comment_to_delete.save()
+            return Response({}, status=status.HTTP_202_ACCEPTED)
+            #return Response({'data': self.destroy(request, *args, **kwargs).data}, status=status.HTTP_202_ACCEPTED)
         except Exception as exc:
             return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -22,27 +22,25 @@ class UserPublicSerializer(serializers.ModelSerializer):
         depth = 1
 
 class PostSerializer(serializers.ModelSerializer):
-
-    # image = Base64ImageField(
-    #     max_length=None, use_url=True,
-    # )
-
     def create(self, data):
         try:
             group = Group.objects.get(id=self.context['view'].kwargs.get("pk"))
         except Exception:
             raise serializers.ValidationError({'error': 'Group Not found'})
         current_user = self.context['request'].user
-        # try:
-        # print(opengraph.OpenGraph(url=data["link"]).__str__())
+
         return Post.objects.create(ogp= opengraph.OpenGraph(url=data["link"]).__str__() if 'link' in data else "",
             link=data.get("link", None), picture=data.get("picture", None), content=data["content"], group=group, creator=current_user)
-        # except Exception:
-            # raise serializers.ValidationError({'error': 'Unknown error while creating post'})
 
     class Meta:
         model = Post
         fields = ('id', 'created_at', 'content', 'creator', 'group', 'picture', 'link', 'ogp', 'likes', 'flags', 'shares')
+        depth = 1
+
+class PostSuperuserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Post
+        fields = ('id', 'created_at', 'content', 'creator', 'group', 'picture', 'link', 'ogp', 'likes', 'flags', 'shares', 'is_deleted')
         depth = 1
 
 class PostLikeSerializer(serializers.ModelSerializer):
@@ -127,6 +125,13 @@ class CommentSerializer(serializers.ModelSerializer):
         post = Post.objects.get(id=self.context['view'].kwargs.get("pk"))
         current_user = self.context['request'].user
         return Comment.objects.create(content=data["content"], post=post, creator=current_user)
+
+class CommentSuperuserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ('id', 'content', 'created_at', 'post', 'creator', 'likes', 'is_deleted')
+        depth = 1
+
 
 class GroupSerializer(serializers.ModelSerializer):
     class Meta:

--- a/kidsbook/user/urls.py
+++ b/kidsbook/user/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path('<uuid:pk>/', views.GetInfoUser.as_view()),
     path('<uuid:pk>/groups/', views.GetGroups.as_view()),
 
-    # path('<uuid:pk>/posts/', views.GetPost.as_view()),
+    path('<uuid:pk>/posts/', views.GetPost.as_view()),
     path('login/', views.LogIn.as_view()),
     path('login_as_virtual/', views.LogInAsVirtual.as_view()),
     path('register/', views.Register.as_view()),

--- a/kidsbook/user/views.py
+++ b/kidsbook/user/views.py
@@ -292,10 +292,11 @@ class GetPost(generics.ListAPIView):
     queryset = ''
     serializer_class = PostSerializer
     permission_classes = (IsAuthenticated, IsTokenValid)
-    def list(self, request):
+    def list(self, request, **kargs):
         try:
-            current_user = request.user
-            posts = Post.objects.filter(creator=current_user).order_by('-created_at')
+            user_id = kargs.get('pk', '')
+            user = User.objects.get(id=user_id)
+            posts = Post.objects.filter(creator=user).exclude(is_deleted=False).order_by('-created_at')
             serializer = PostSerializer(posts, many=True)
             return Response({'data': serializer.data})
         except Exception as e:

--- a/kidsbook/user/views.py
+++ b/kidsbook/user/views.py
@@ -296,7 +296,7 @@ class GetPost(generics.ListAPIView):
         try:
             user_id = kargs.get('pk', '')
             user = User.objects.get(id=user_id)
-            posts = Post.objects.filter(creator=user).exclude(is_deleted=False).order_by('-created_at')
+            posts = Post.objects.filter(creator=user).exclude(is_deleted=True).order_by('-created_at')
             serializer = PostSerializer(posts, many=True)
             return Response({'data': serializer.data})
         except Exception as e:


### PR DESCRIPTION
Issue #47 
1. Add field `is_deleted` to model `Post` and `Comment`.
2. Now set a flag `is_deleted=True` instead of removing a post/comment.
    - `DELETE /post/<post_id>/`
    - `DELETE /comment/<comment_id>/`

3. Change the update response's status code for non-creator of a group from `401` to `405`.

4. Only the following APIs return the full list of posts/comments (require `IsSuperUser`):
    - `GET /group/<group_id>/flagged/`
    - `GET /group/<group_id>/posts/?all=true`
    - `GET /post/<post_id>/comments/?all=true`