### PR TITLE
Hieu6

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Method | Endpoint | Arguments | Description | Permissions | Return
 `GET` | /user/virtual_users/ | | Get all `virtual` users created by the requester. | IsAuthenticated, IsSuperUser | User: *list*
 `POST` | /user/logout/ | | Disable the requester's token. | IsAuthenticated | {}
 `POST` | /user/update/<user_id/ | * (If update password then need `oldPassword` and `password`) | Update an user using the given arguments. | IsAuthenticated. The requester must be either the creator of the user, the user himself or a superuser in a same group. | User: *dict*
+`POST` | /user/record_time/ |'timestamp': The current epoch time | Ping request to record time. | IsAuthenticated | {}
+
 
 ## 2. Users
 

--- a/kidsbook/models.py
+++ b/kidsbook/models.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-
+import datetime
 import uuid
 import bcrypt
 from django.db import models
@@ -101,11 +101,12 @@ class User(AbstractBaseUser, PermissionsMixin):
     created_at = models.DateTimeField(auto_now_add=True)
     profile_photo = models.ImageField(null=True)
     login_time = models.PositiveIntegerField(default=0)
-    screen_time = models.PositiveIntegerField(default=0)
+    # screen_time = models.PositiveIntegerField(default=0)
     profile_photo = models.ImageField(default="default.png", null=True)
 
     teacher = models.ForeignKey('self', related_name='teacher_in_chage', on_delete=models.CASCADE, null=True)
     is_active = models.BooleanField(default=True)
+    last_active_time = models.PositiveIntegerField(default=0)
     # role_id = models.ForeignKey(Role, related_name='post_owner', on_delete=models.CASCADE, default=0)
     role = models.ForeignKey(Role, related_name='group_owner', on_delete=models.CASCADE)
 
@@ -128,6 +129,12 @@ class User(AbstractBaseUser, PermissionsMixin):
     #         return True
     #     else:
     #         return False
+
+class ScreenTime(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.ForeignKey(User, related_name='screen_time', on_delete=models.CASCADE)
+    date = models.DateField(_("Date"), default=datetime.date.today)
+    total_time = models.FloatField(default=0)
 
 class BlackListedToken(models.Model):
     token = models.CharField(max_length=500)

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -7,11 +7,12 @@ User = get_user_model()
 import opengraph
 import json
 
+
 # This is for private profile
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'username', 'email_address', 'is_active', 'profile_photo', 'is_superuser', 'description', "realname", 'group_users', 'user_posts', 'role', 'created_at')
+        fields = ('id', 'username', 'email_address', 'is_active', 'profile_photo', 'is_superuser', 'description', "realname", 'group_users', 'user_posts', 'role', 'created_at', 'last_active_time')
         depth = 1
 
 # This class is for public profile

--- a/kidsbook/user/urls.py
+++ b/kidsbook/user/urls.py
@@ -5,6 +5,7 @@ from kidsbook.user import views
 urlpatterns = [
     # Get User's Info
     # path('all/', views.GetAllUser.as_view()),
+    path('record_time/', views.RecordTime.as_view()),
     path('<uuid:pk>/', views.GetInfoUser.as_view()),
     path('<uuid:pk>/groups/', views.GetGroups.as_view()),
 

--- a/kidsbook/users/views.py
+++ b/kidsbook/users/views.py
@@ -10,6 +10,7 @@ from itertools import chain
 from kidsbook.serializers import *
 from kidsbook.models import *
 from kidsbook.permissions import *
+from kidsbook.utils import *
 
 User = get_user_model()
 
@@ -69,6 +70,9 @@ def users_allowed_to_be_discovered(request):
         result_list = list(set(chain(users_not_in_any_groups, all_superusers, all_users_in_same_groups, users_created_by_requester)))
         result_list = sorted(result_list, key=lambda instance: instance.created_at, reverse=True)
         serializer = UserSerializer(result_list, many=True)
+
+        for user in serializer.data:
+            user['time_history'] = usage_time(User.objects.get(id=user['id']))
 
         return Response({'data': serializer.data})
     except Exception as exc:

--- a/kidsbook/utils.py
+++ b/kidsbook/utils.py
@@ -1,3 +1,5 @@
+from kidsbook.models import *
+
 def clean_data(data, *args):
   for field in args:
     data.pop(field, None)
@@ -8,3 +10,14 @@ def clean_data_iterative(data, *args):
     for field in args:
       row.pop(field, None)
   return data
+
+def usage_time(user):
+  arr = []
+  for i in range(7):
+    day = (datetime.datetime.now() - datetime.timedelta(days=i)).date()
+    if(ScreenTime.objects.filter(user=user, date=day)):
+      time = ScreenTime.objects.get(user=user, date=day).total_time
+    else:
+      time = 0
+    arr.append(time)
+  return arr


### PR DESCRIPTION
CHANGELOG:
Front-end will send request every 30 seconds(can discuss this later).

User Model has extra field: last_active_at

ScreenTime Model that keeps track of total_time for an user at a date.

APIs:

1/ Record screen time(POST /user/record_time/): The request should contain "timestamp" which is the current UNIX timestamp.

2/ Get profile of user(GET /user/<user_id>/profile/): and Get all users in user managements(GET /users/):

If this user can get the private profile, then it will include a new field "time_history" like this:

![screenshot from 2018-10-31 19-46-48](https://user-images.githubusercontent.com/21095940/47786471-d5402480-dd46-11e8-970c-b4327202286a.png)

![screenshot from 2018-10-31 19-47-11](https://user-images.githubusercontent.com/21095940/47786474-d8d3ab80-dd46-11e8-85a8-b17d591264ec.png)
