### PR TITLE
Optimize ORM for Notifications 

### DIFF
--- a/kidsbook/group/views.py
+++ b/kidsbook/group/views.py
@@ -92,7 +92,7 @@ def add_member_to_group(user, group):
     noti_user.number_of_unseen += 1
     noti_user.save()
 
-    # Push the notification to all users in group
+    # Push the notification the newly added user
     if UserSetting.objects.get(user_id=user.id).receive_notifications:
         noti_serializer = NotificationSerializer(noti).data
         push_notification(noti_serializer)
@@ -114,7 +114,7 @@ def delete_member_from_group(user, group):
     noti_user.number_of_unseen += 1
     noti_user.save()
 
-    # Push the notification to all users in group
+    # Push the notification to the deleted user
     if UserSetting.objects.get(user_id=user.id).receive_notifications:
         noti_serializer = NotificationSerializer(noti).data
         push_notification(noti_serializer)

--- a/kidsbook/notification/views.py
+++ b/kidsbook/notification/views.py
@@ -24,11 +24,12 @@ def get_notifications(request):
     """
 
     try:
-        notifications = Notification.objects.filter(user_id=request.user.id).order_by('-created_at')
+        requester_id = request.user.id
+        notifications = Notification.objects.filter(user_id=requester_id).order_by('-created_at')
         if len(notifications) > 50:
             notifications = notifications[:50]
 
-        number_of_unseen = NotificationUser.objects.get(user_id=request.user.id).number_of_unseen
+        number_of_unseen = NotificationUser.objects.get(user_id=requester_id).number_of_unseen
     except Exception as exc:
         return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/kidsbook/serializers.py
+++ b/kidsbook/serializers.py
@@ -28,7 +28,7 @@ class UserSettingSerializer(serializers.ModelSerializer):
         model = UserSetting
         fields = ('id', 'user', 'receive_notifications')
         depth = 1
-        
+
 class NestedUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
@@ -62,16 +62,19 @@ class PostSerializer(serializers.ModelSerializer):
         #depth = 1
 
 class NotificationSerializer(serializers.ModelSerializer):
+    user = NestedUserSerializer(read_only=True)
+    action_user = NestedUserSerializer(read_only=True)
+
     class Meta:
         model = Notification
         fields = ('id', 'created_at', 'content', 'user', 'group', 'post', 'action_user')
-        depth = 1
+        #depth = 1
 
 class NotificationUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = NotificationUser
         fields = ('id', 'user', 'number_of_unseen')
-        depth = 1
+        #depth = 1
 
 class PostSuperuserSerializer(serializers.ModelSerializer):
     creator = NestedUserSerializer(read_only=True)


### PR DESCRIPTION
### 1. Optimize ORM for Notifications
`Notification` response's format has fields:
 `'id', 'created_at', 'content', 'user', 'group', 'post', 'action_user'`. 

`group` and `post` now only has the `id`, while `user` and `action_user` stay as nested objects.

### 2. Fix pushing notifications when post's creator comments on his post